### PR TITLE
UI-6728 - Migrate katex formulas

### DIFF
--- a/.vscode/jest.launch.config.js
+++ b/.vscode/jest.launch.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require("@activeviam/activeui-sdk-scripts/dist/configs/jest");
+
+module.exports = jestConfig.default;

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File (default config)",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "${fileBasenameNoExtension}",
+        "--config",
+        ".vscode/jest.launch.config.js",
+        "--roots",
+        "${workspaceFolder}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds handling of katex formula migration:

Old notation
```
$ inline formula $
$$ block formula $$
```

becomes
```
`katex inline formula`

```katex
block formula
 \```
```