### PR TITLE
UI-6890 - Fix migration script failing on text editor widgets when run with nodeJS < v15

### DIFF
--- a/src/migrateTextEditor.ts
+++ b/src/migrateTextEditor.ts
@@ -27,7 +27,7 @@ export function migrateTextEditor(
    * - (.*) capturing group for anything between the single '$'.
    * - /g mandatory global flag when using "replaceAll".
    */
-  const textWithInlineKatexFormulasReplaced = (text as string).replaceAll(
+  const textWithInlineKatexFormulasReplaced = (text as string).replace(
     /(?<!\$)\$(?!\$)(.*)(?<!\$)\$(?!\$)/g,
     "`katex $1`"
   );
@@ -48,7 +48,7 @@ export function migrateTextEditor(
    * - s flag allowing "." to match new lines.
    */
   const textWithBlickKatexFormulasReplaced =
-    textWithInlineKatexFormulasReplaced.replaceAll(
+    textWithInlineKatexFormulasReplaced.replace(
       /\${2}(.*)\${2}/gs,
       "```katex\n$1\n```"
     );


### PR DESCRIPTION
The used regular expressions already used `g`, making `.replaceAll` directly convertible into `.replace`.

I checked that `migrateTextEditor.test.ts` still passes. It does. Too bad we do not have a CI here yet, which tells it unambiguously to the reviewer.