### PR TITLE
UI-6956 - Fix command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ At this stage, your `migration` folder looks like this:
 Open a terminal in it and run:
 
 ```
-npm run migrate -i "content of ui.json" -o migrated-content.json -s servers.json
+npx migrate -i "content of ui.json" -o migrated-content.json -s servers.json
 ```
 
 This command generates a file named `migrated-content.json` in the same folder. It contains the migrated content, ready to be used in ActiveUI 5.


### PR DESCRIPTION
`npm run` does not run executables. In fact it's not even listed in the [`npm` CLI](https://docs.npmjs.com/cli/v7/commands).
[`npm exec`](https://docs.npmjs.com/cli/v7/commands/npm-exec) or [`npx`](https://docs.npmjs.com/cli/v7/commands/npx) should be used instead.
In our case, `npx` is more straightforward to avoid having to separate `npm exec` arguments from the actual executable arguments, (see the [docs](https://docs.npmjs.com/cli/v7/commands/npx#npx-vs-npm-exec)).

Alternatives: 
- document using `yarn` instead of `npm`.
- do not go through the trouble of [creating a directory, doing `npm init`, `npm install activeui-migration`, and then only `npx migrate`], and rather temporarily install `activeui-migration` globally and run the command in one go through `npx -p activeui-migration migrate`

My favorite option is the last one.
It makes sure that you're always using the latest version of the command, reduces the README to one line, and makes it super straightforward for users.
But I remember telling you about that idea and that you did not like it so I did not go for it. Do you confirm @Nouzbe ?