### PR TITLE
UI-7198 - Fix running the CLI with Node 16

### DIFF
--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -39,6 +39,9 @@ yargs
       const servers = await fs.readJSON(serversPath);
       const migratedUIFolder = migrateUIFolder(legacyUIFolder, servers);
       await fs.writeJSON(outputPath, migratedUIFolder, { spaces: 2 });
+      // FIXME Rely on yargs instead of having to call process.exit manually.
+      // See https://support.activeviam.com/jira/browse/UI-7198
+      process.exit(0);
     }
   )
   .demandCommand(1)


### PR DESCRIPTION
The problem is explained in the ticket description: [UI-7198](https://support.activeviam.com/jira/browse/UI-7198)

I haven't found a better solution than to call `process.exit` manually.
In particular, I have researched things like "yargs Node 16 process not exiting", and the polyfill warnings, and I did not find any related issue.

To test, having [this ](https://github.com/activeviam/activeui-migration/pull/4) merged would have been helpful, so I'm glad we're in the process of adding it.
In the meantime, you can use [`npm link`](https://docs.npmjs.com/cli/v8/commands/npm-link):
```bash
// Starting from activeui-migration:
git co personal/a.tissier/UI-7198-fix-cli-with-node-16
git pull
yarn && yarn build
npm link
cd ..
mkdir migration_test
npm init
npm link activeui-migration
npx migrate -i ../activeui-migration/src/__test_resources__/aui4_ui_folder.json -s ../activeui-migration/src/__test_resources__/servers.json -o output.json
```