### PR TITLE
UI-7417 - Handle nodes with missing content

### DIFF
--- a/src/migrateUIFolder.ts
+++ b/src/migrateUIFolder.ts
@@ -170,7 +170,7 @@ const accumulateStructure = ({
             },
           },
         };
-      } else {
+      } else if (folders[id] !== undefined) {
         accumulateStructure({
           legacyUIFolder,
           migratedUIFolder,
@@ -180,6 +180,10 @@ const accumulateStructure = ({
           folders,
           path: [...path, id],
         });
+      } else {
+        console.error(
+          `The 'structure' folder contains an object of id '${id}' that could not be identified (missing or corrupted entry in 'content'). Children of that object will be ignored.`
+        );
       }
     }
   }
@@ -291,6 +295,10 @@ export function migrateUIFolder(
           );
         }
       }
+    } else {
+      console.error(
+        `The 'content' folder contains a corrupted object of id '${id}' (no content found).`
+      );
     }
   }
 


### PR DESCRIPTION
If it happens that bookmarks are missing the `content` attribute in their `ContentEntry`, the migration tool now reports it gracefully and does not go down these node's `structure`. Doing so would trigger an error when resolving the path of these children and assuming that their parent are folders.

With no content we cannot determine the type of the node and are basically helpless.