### PR TITLE
UI-7687 - Bump ubuntu executor version

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   Auto:
     name: Auto-update
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: tibdex/auto-update@v2
         with:

--- a/.github/workflows/jira-check.yml
+++ b/.github/workflows/jira-check.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   jira-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Jira Check
     steps:
       - name: Jira Check


### PR DESCRIPTION
Current version is deprecated and will cease to work on december 1st.