### PR TITLE
UI-7948 - Introduce aliases to allow using multiple versions of packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@activeviam/activeui-sdk": "5.0.15",
-    "@activeviam/content-server-initialization": "5.0.15",
-    "@activeviam/data-model": "5.0.15",
-    "@activeviam/mdx": "5.0.15",
+    "@activeviam/activeui-sdk-5.0": "npm:@activeviam/activeui-sdk@5.0.15",
+    "@activeviam/content-server-initialization-5.0": "npm:@activeviam/content-server-initialization@5.0.15",
+    "@activeviam/data-model-5.0": "npm:@activeviam/data-model@5.0.15",
+    "@activeviam/mdx-5.0": "npm:@activeviam/mdx@5.0.15",
     "cli-progress": "^3.11.2",
     "immer": "^8.0.0",
     "lodash": "^4.17.15",

--- a/src/__test_resources__/legacyUIFolder.ts
+++ b/src/__test_resources__/legacyUIFolder.ts
@@ -1,4 +1,4 @@
-import { ContentRecord } from "@activeviam/activeui-sdk";
+import { ContentRecord } from "@activeviam/activeui-sdk-5.0";
 import { legacySettingsFolder } from "../legacySettingsFolder";
 
 /**

--- a/src/__test_resources__/servers.ts
+++ b/src/__test_resources__/servers.ts
@@ -1,4 +1,4 @@
-import { dataModelsForTests } from "@activeviam/data-model";
+import { dataModelsForTests } from "@activeviam/data-model-5.0";
 
 /**
  * A datamodel and URL, useful to unit test the migration scripts.

--- a/src/_doesCrossjoinRepresentAnExpandedMember.test.ts
+++ b/src/_doesCrossjoinRepresentAnExpandedMember.test.ts
@@ -1,6 +1,6 @@
-import { MdxFunction, parse } from "@activeviam/activeui-sdk";
+import { MdxFunction, parse } from "@activeviam/activeui-sdk-5.0";
 import { _doesCrossjoinRepresentAnExpandedMember } from "./_doesCrossjoinRepresentAnExpandedMember";
-import { dataModelsForTests } from "@activeviam/data-model";
+import { dataModelsForTests } from "@activeviam/data-model-5.0";
 
 const cube = dataModelsForTests.sandbox.catalogs[0].cubes[0];
 

--- a/src/_doesCrossjoinRepresentAnExpandedMember.ts
+++ b/src/_doesCrossjoinRepresentAnExpandedMember.ts
@@ -1,10 +1,10 @@
-import { Cube } from "@activeviam/data-model";
+import { Cube } from "@activeviam/data-model-5.0";
 import {
   getSpecificCompoundIdentifier,
   isMdxCompoundIdentifier,
   isMdxFunction,
   MdxFunction,
-} from "@activeviam/mdx";
+} from "@activeviam/mdx-5.0";
 
 /**
  * Returns whether `crossjoin` represents an expanded member on an axis.

--- a/src/_doesCrossjoinYieldAllCombinationsOfMembers.test.ts
+++ b/src/_doesCrossjoinYieldAllCombinationsOfMembers.test.ts
@@ -1,6 +1,6 @@
-import { MdxFunction, parse } from "@activeviam/activeui-sdk";
+import { MdxFunction, parse } from "@activeviam/activeui-sdk-5.0";
 import { _doesCrossjoinYieldAllCombinationsOfMembers } from "./_doesCrossjoinYieldAllCombinationsOfMembers";
-import { dataModelsForTests } from "@activeviam/data-model";
+import { dataModelsForTests } from "@activeviam/data-model-5.0";
 
 const cube = dataModelsForTests.sandbox.catalogs[0].cubes[0];
 

--- a/src/_doesCrossjoinYieldAllCombinationsOfMembers.ts
+++ b/src/_doesCrossjoinYieldAllCombinationsOfMembers.ts
@@ -3,8 +3,8 @@ import {
   LevelCoordinates,
   isMdxCompoundIdentifier,
   MdxFunction,
-} from "@activeviam/activeui-sdk";
-import { findLevels, getSpecificCompoundIdentifier } from "@activeviam/mdx";
+} from "@activeviam/activeui-sdk-5.0";
+import { findLevels, getSpecificCompoundIdentifier } from "@activeviam/mdx-5.0";
 
 /**
  * Returns whether `crossjoin` yields all combinations of members of the hierarchies expressed on the axis.

--- a/src/_findErroneousUnionNode.test.ts
+++ b/src/_findErroneousUnionNode.test.ts
@@ -1,6 +1,6 @@
-import { MdxSelect, parse, stringify } from "@activeviam/activeui-sdk";
+import { MdxSelect, parse, stringify } from "@activeviam/activeui-sdk-5.0";
 import { _findErroneousUnionNode } from "./_findErroneousUnionNode";
-import { dataModelsForTests } from "@activeviam/data-model";
+import { dataModelsForTests } from "@activeviam/data-model-5.0";
 
 const cube = dataModelsForTests.sandbox.catalogs[0].cubes[0];
 

--- a/src/_findErroneousUnionNode.ts
+++ b/src/_findErroneousUnionNode.ts
@@ -4,8 +4,8 @@ import {
   isMdxFunction,
   Mdx,
   MdxFunction,
-} from "@activeviam/activeui-sdk";
-import { findDescendant } from "@activeviam/mdx";
+} from "@activeviam/activeui-sdk-5.0";
+import { findDescendant } from "@activeviam/mdx-5.0";
 
 import { _doesCrossjoinRepresentAnExpandedMember } from "./_doesCrossjoinRepresentAnExpandedMember";
 import { _doesCrossjoinYieldAllCombinationsOfMembers } from "./_doesCrossjoinYieldAllCombinationsOfMembers";

--- a/src/_fixErroneousExpansionMdx.test.ts
+++ b/src/_fixErroneousExpansionMdx.test.ts
@@ -1,8 +1,8 @@
 import _cloneDeep from "lodash/cloneDeep";
-import { MdxSelect, parse, stringify } from "@activeviam/activeui-sdk";
+import { MdxSelect, parse, stringify } from "@activeviam/activeui-sdk-5.0";
 
 import { _fixErroneousExpansionMdx } from "./_fixErroneousExpansionMdx";
-import { dataModelsForTests } from "@activeviam/data-model";
+import { dataModelsForTests } from "@activeviam/data-model-5.0";
 
 const cube = dataModelsForTests.sandbox.catalogs[0].cubes[0];
 

--- a/src/_fixErroneousExpansionMdx.ts
+++ b/src/_fixErroneousExpansionMdx.ts
@@ -5,8 +5,8 @@ import {
   MdxDrillthrough,
   getLevels,
   Cube,
-} from "@activeviam/activeui-sdk";
-import { isMdxDrillthrough } from "@activeviam/mdx";
+} from "@activeviam/activeui-sdk-5.0";
+import { isMdxDrillthrough } from "@activeviam/mdx-5.0";
 
 import { _doesCrossjoinRepresentAnExpandedMember } from "./_doesCrossjoinRepresentAnExpandedMember";
 import {

--- a/src/_flattenLayout.ts
+++ b/src/_flattenLayout.ts
@@ -1,4 +1,4 @@
-import type { Layout, LayoutLeaf } from "@activeviam/activeui-sdk";
+import type { Layout, LayoutLeaf } from "@activeviam/activeui-sdk-5.0";
 
 import { isLegacyLayoutLeaf } from "./isLegacyLayoutLeaf";
 import type { LegacyLayout, LegacyLayoutLeaf } from "./migration.types";

--- a/src/_getFolderName.ts
+++ b/src/_getFolderName.ts
@@ -1,4 +1,4 @@
-import { ContentRecord } from "@activeviam/activeui-sdk";
+import { ContentRecord } from "@activeviam/activeui-sdk-5.0";
 
 /**
  * Returns an array containing the names of each folder identified by their ids in `pathOfIds`.

--- a/src/_getMapOfFolderIds.ts
+++ b/src/_getMapOfFolderIds.ts
@@ -1,4 +1,4 @@
-import { ContentRecord } from "@activeviam/activeui-sdk";
+import { ContentRecord } from "@activeviam/activeui-sdk-5.0";
 
 function addChildren(
   node: ContentRecord,

--- a/src/_getTargetCubeFromServerUrl.ts
+++ b/src/_getTargetCubeFromServerUrl.ts
@@ -1,12 +1,12 @@
 import _mapValues from "lodash/mapValues";
 import _findKey from "lodash/findKey";
-import { getCubeName, getTargetCube } from "@activeviam/activeui-sdk";
+import { getCubeName, getTargetCube } from "@activeviam/activeui-sdk-5.0";
 import type {
   Cube,
   DataModel,
   MdxDrillthrough,
   MdxSelect,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 
 /**
  * Returns the serverKey, dataModel and cube targeted by the given `mdx` from a legacy AUI4 widget,

--- a/src/_migrateContextValues.ts
+++ b/src/_migrateContextValues.ts
@@ -1,6 +1,6 @@
 import _forEach from "lodash/forEach";
 import _map from "lodash/map";
-import type { QueryContextEntry } from "@activeviam/activeui-sdk";
+import type { QueryContextEntry } from "@activeviam/activeui-sdk-5.0";
 
 export interface LegacyContextValues {
   [key: string]: string | number | boolean;

--- a/src/_migrateQuery.test.ts
+++ b/src/_migrateQuery.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import { dataModelsForTests } from "@activeviam/data-model";
-import { stringify } from "@activeviam/activeui-sdk";
+import { dataModelsForTests } from "@activeviam/data-model-5.0";
+import { stringify } from "@activeviam/activeui-sdk-5.0";
 import { LegacyQuery, _migrateQuery } from "./_migrateQuery";
 
 const cube = dataModelsForTests.sandbox.catalogs[0].cubes[0];

--- a/src/_migrateQuery.ts
+++ b/src/_migrateQuery.ts
@@ -5,8 +5,8 @@ import type {
   Mdx,
   MdxDrillthrough,
   MdxSelect,
-} from "@activeviam/activeui-sdk";
-import { getFilters, parse, setFilters } from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
+import { getFilters, parse, setFilters } from "@activeviam/activeui-sdk-5.0";
 import { _fixErroneousExpansionMdx } from "./_fixErroneousExpansionMdx";
 import {
   LegacyContextValues,

--- a/src/_migrateTableColumnWidths.test.ts
+++ b/src/_migrateTableColumnWidths.test.ts
@@ -1,5 +1,5 @@
-import { dataModelsForTests } from "@activeviam/data-model";
-import type { DataVisualizationWidgetMapping } from "@activeviam/activeui-sdk";
+import { dataModelsForTests } from "@activeviam/data-model-5.0";
+import type { DataVisualizationWidgetMapping } from "@activeviam/activeui-sdk-5.0";
 import { _migrateTableColumnWidths } from "./_migrateTableColumnWidths";
 
 const cube = dataModelsForTests.sandbox.catalogs[0].cubes[0];

--- a/src/_migrateTableColumnWidths.ts
+++ b/src/_migrateTableColumnWidths.ts
@@ -1,14 +1,14 @@
 import type {
   Cube,
   DataVisualizationWidgetMapping,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 import {
   isMdxCompoundIdentifier,
   isMdxFunction,
   parse,
   quote,
-} from "@activeviam/activeui-sdk";
-import { getSpecificCompoundIdentifier } from "@activeviam/mdx";
+} from "@activeviam/activeui-sdk-5.0";
+import { getSpecificCompoundIdentifier } from "@activeviam/mdx-5.0";
 
 interface LegacyColumn {
   key: string;

--- a/src/errors/PartialMigrationError.ts
+++ b/src/errors/PartialMigrationError.ts
@@ -1,4 +1,4 @@
-import { AWidgetState } from "@activeviam/activeui-sdk";
+import { AWidgetState } from "@activeviam/activeui-sdk-5.0";
 
 /**
  * Thrown when an object could only be partially migrated.

--- a/src/errors/TextEditorWidgetMigrationError.ts
+++ b/src/errors/TextEditorWidgetMigrationError.ts
@@ -1,4 +1,4 @@
-import { TextEditorWidgetState } from "@activeviam/activeui-sdk";
+import { TextEditorWidgetState } from "@activeviam/activeui-sdk-5.0";
 import { PartialMigrationError } from "./PartialMigrationError";
 
 /**

--- a/src/errors/UnsupportedLegacyQueryUpdateModeError.ts
+++ b/src/errors/UnsupportedLegacyQueryUpdateModeError.ts
@@ -1,4 +1,4 @@
-import { AWidgetState } from "@activeviam/activeui-sdk";
+import { AWidgetState } from "@activeviam/activeui-sdk-5.0";
 import { PartialMigrationError } from "./PartialMigrationError";
 
 /**

--- a/src/getCalculatedMeasures.ts
+++ b/src/getCalculatedMeasures.ts
@@ -1,4 +1,4 @@
-import { ContentRecord } from "@activeviam/activeui-sdk";
+import { ContentRecord } from "@activeviam/activeui-sdk-5.0";
 import xml2js from "xml2js";
 import _flatMap from "lodash/flatMap";
 import { LegacyCalculatedMeasure } from "./migrateCalculatedMeasures";

--- a/src/legacySettingsFolder.ts
+++ b/src/legacySettingsFolder.ts
@@ -1,4 +1,4 @@
-import type { ContentRecord } from "@activeviam/activeui-sdk";
+import type { ContentRecord } from "@activeviam/activeui-sdk-5.0";
 
 const defaultPreferences = {
   allow: [],

--- a/src/migrateCalculatedMeasures.ts
+++ b/src/migrateCalculatedMeasures.ts
@@ -1,4 +1,4 @@
-import { ContentRecord } from "@activeviam/activeui-sdk";
+import { ContentRecord } from "@activeviam/activeui-sdk-5.0";
 import { getCalculatedMeasures } from "./getCalculatedMeasures";
 import { generateId } from "./generateId";
 

--- a/src/migrateChart.ts
+++ b/src/migrateChart.ts
@@ -24,7 +24,7 @@ import {
   pluginWidgetPlotlyBulletChart,
   pluginWidgetPlotlyTreeMap,
   pluginWidgetPlotlyStackedAreaChart,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 import type {
   PlotlyWidgetState,
   DataModel,
@@ -33,7 +33,7 @@ import type {
   Query,
   WidgetPlugin,
   SerializedDataVisualizationWidgetMapping,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 import { _getTargetCubeFromServerUrl } from "./_getTargetCubeFromServerUrl";
 import { LegacyQuery, _migrateQuery } from "./_migrateQuery";
 import { UnsupportedLegacyChartTypeError } from "./errors/UnsupportedLegacyChartTypeError";

--- a/src/migrateDashboard.ts
+++ b/src/migrateDashboard.ts
@@ -12,7 +12,7 @@ import {
   serializeDashboardState,
   Layout,
   AWidgetState,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 import { _flattenLayout, _convertFromLegacyLayout } from "./_flattenLayout";
 import { migrateWidget } from "./migrateWidget";
 

--- a/src/migrateDrillthrough.ts
+++ b/src/migrateDrillthrough.ts
@@ -3,8 +3,8 @@ import type {
   DataModel,
   MdxDrillthrough,
   DrillthroughTableWidgetState,
-} from "@activeviam/activeui-sdk";
-import { serializeWidgetState, parse } from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
+import { serializeWidgetState, parse } from "@activeviam/activeui-sdk-5.0";
 import { UnsupportedLegacyQueryUpdateModeError } from "./errors/UnsupportedLegacyQueryUpdateModeError";
 import { _getQueryInLegacyWidgetState } from "./_getQueryInLegacyWidgetState";
 import { _getTargetCubeFromServerUrl } from "./_getTargetCubeFromServerUrl";

--- a/src/migrateFilter.ts
+++ b/src/migrateFilter.ts
@@ -1,4 +1,4 @@
-import type { CubeName, MdxString } from "@activeviam/activeui-sdk";
+import type { CubeName, MdxString } from "@activeviam/activeui-sdk-5.0";
 interface LegacyFilter {
   name: string;
   type: "mdx";

--- a/src/migrateKpi.ts
+++ b/src/migrateKpi.ts
@@ -5,7 +5,7 @@ import type {
   KpiComparison,
   MdxSelect,
   KpiWidgetState,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 import {
   parse,
   stringify,
@@ -13,8 +13,8 @@ import {
   pluginWidgetKpi,
   serializeWidgetState,
   deriveMappingFromMdx,
-} from "@activeviam/activeui-sdk";
-import { getSpecificCompoundIdentifier } from "@activeviam/mdx";
+} from "@activeviam/activeui-sdk-5.0";
+import { getSpecificCompoundIdentifier } from "@activeviam/mdx-5.0";
 import { UnsupportedLegacyQueryUpdateModeError } from "./errors/UnsupportedLegacyQueryUpdateModeError";
 import { _getQueryInLegacyWidgetState } from "./_getQueryInLegacyWidgetState";
 import { _getTargetCubeFromServerUrl } from "./_getTargetCubeFromServerUrl";

--- a/src/migrateQuickFilter.ts
+++ b/src/migrateQuickFilter.ts
@@ -7,7 +7,7 @@ import {
   QuickFilterWidgetState,
   getTargetCube,
   getHierarchy,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 
 const _getMode = ({
   displayedAsSelect,

--- a/src/migrateSettingsFolder.ts
+++ b/src/migrateSettingsFolder.ts
@@ -6,8 +6,8 @@ import type {
   ContentRecord,
   Settings,
   MdxString,
-} from "@activeviam/activeui-sdk";
-import { emptyUIFolder } from "@activeviam/content-server-initialization";
+} from "@activeviam/activeui-sdk-5.0";
+import { emptyUIFolder } from "@activeviam/content-server-initialization-5.0";
 
 const emptySettingsFolders = _pick(
   emptyUIFolder.children,

--- a/src/migrateTable.test.ts
+++ b/src/migrateTable.test.ts
@@ -1,4 +1,8 @@
-import { parse, stringify, TableWidgetState } from "@activeviam/activeui-sdk";
+import {
+  parse,
+  stringify,
+  TableWidgetState,
+} from "@activeviam/activeui-sdk-5.0";
 import _cloneDeep from "lodash/cloneDeep";
 import { migrateTable } from "./migrateTable";
 import { emptyLegacyTable } from "./__test_resources__/emptyLegacyTable";

--- a/src/migrateTable.ts
+++ b/src/migrateTable.ts
@@ -3,7 +3,7 @@ import type {
   DataModel,
   MdxSelect,
   TableWidgetState,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 import {
   serializeWidgetState,
   deriveMappingFromMdx,
@@ -11,7 +11,7 @@ import {
   pluginWidgetPivotTable,
   pluginWidgetTable,
   pluginWidgetTreeTable,
-} from "@activeviam/activeui-sdk";
+} from "@activeviam/activeui-sdk-5.0";
 import { UnsupportedLegacyQueryUpdateModeError } from "./errors/UnsupportedLegacyQueryUpdateModeError";
 import { _getQueryInLegacyWidgetState } from "./_getQueryInLegacyWidgetState";
 import { _getTargetCubeFromServerUrl } from "./_getTargetCubeFromServerUrl";

--- a/src/migrateTextEditor.ts
+++ b/src/migrateTextEditor.ts
@@ -1,4 +1,4 @@
-import type { TextEditorWidgetState } from "@activeviam/activeui-sdk";
+import type { TextEditorWidgetState } from "@activeviam/activeui-sdk-5.0";
 import type { LegacyWidgetState } from "./migration.types";
 
 /**

--- a/src/migrateUIFolder.test.ts
+++ b/src/migrateUIFolder.test.ts
@@ -4,7 +4,7 @@ import { migrateUIFolder } from "./migrateUIFolder";
 import { smallLegacyUIFolder } from "./__test_resources__/smallLegacyUIFolder";
 import { legacyUIFolder } from "./__test_resources__/legacyUIFolder";
 import { servers } from "./__test_resources__/servers";
-import { ContentRecord } from "@activeviam/activeui-sdk";
+import { ContentRecord } from "@activeviam/activeui-sdk-5.0";
 import { LegacyDashboardState } from "./migration.types";
 import { smallLegacyPivotFolder } from "./__test_resources__/smallLegacyPivotFolder";
 import { smallLegacyUIFolderWithInvalidFilter } from "./__test_resources__/smallLegacyUIFolderWithInvalidFilter";

--- a/src/migrateUIFolder.ts
+++ b/src/migrateUIFolder.ts
@@ -4,8 +4,12 @@ import _setWith from "lodash/setWith";
 import _omit from "lodash/omit";
 import _fromPairs from "lodash/fromPairs";
 
-import { ContentRecord, DataModel, MdxString } from "@activeviam/activeui-sdk";
-import { emptyUIFolder } from "@activeviam/content-server-initialization";
+import {
+  ContentRecord,
+  DataModel,
+  MdxString,
+} from "@activeviam/activeui-sdk-5.0";
+import { emptyUIFolder } from "@activeviam/content-server-initialization-5.0";
 
 import { migrateDashboard } from "./migrateDashboard";
 import { migrateWidget } from "./migrateWidget";

--- a/src/migrateWidget.ts
+++ b/src/migrateWidget.ts
@@ -1,4 +1,4 @@
-import type { AWidgetState, DataModel } from "@activeviam/activeui-sdk";
+import type { AWidgetState, DataModel } from "@activeviam/activeui-sdk-5.0";
 import type { LegacyWidgetState } from "./migration.types";
 
 import { migrateChart } from "./migrateChart";

--- a/src/migration.types.ts
+++ b/src/migration.types.ts
@@ -1,4 +1,4 @@
-import type { MdxString } from "@activeviam/activeui-sdk";
+import type { MdxString } from "@activeviam/activeui-sdk-5.0";
 import type { LegacyContextValues } from "./_migrateContextValues";
 
 export interface LegacyLayoutLeaf {

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,70 +34,7 @@
     lodash "^4.17.15"
     tslib "^2.0.0"
 
-"@activeviam/activeui-sdk-scripts@5.0.15":
-  version "5.0.15"
-  resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/activeui-sdk-scripts/-/@activeviam/activeui-sdk-scripts-5.0.15.tgz#d2aec0a31978c5fc21a38e91ea9d2dc1dc9dbd9a"
-  integrity sha512-wHozxUFqHMtWSbI2Ceu/f2QgT1arhtM0L4S/m5/DpU4pEhGXKDkoUzDO6Xtz14Jl4az4VQdTwgDgYyOH+QAO0g==
-  dependencies:
-    "@activeviam/content-server-initialization" "5.0.15"
-    "@babel/cli" "^7.11.6"
-    "@babel/core" "^7.12.16"
-    "@babel/plugin-proposal-class-properties" "^7.10.4"
-    "@babel/plugin-proposal-optional-chaining" "^7.11.0"
-    "@babel/plugin-transform-runtime" "^7.11.5"
-    "@babel/preset-env" "^7.12.16"
-    "@babel/preset-react" "^7.12.13"
-    "@babel/preset-typescript" "^7.12.16"
-    "@parcel/css" "^1.5.0"
-    "@rollup/plugin-babel" "^5.2.1"
-    "@rollup/plugin-commonjs" "^15.1.0"
-    "@rollup/plugin-json" "^4.1.0"
-    "@rollup/plugin-node-resolve" "^9.0.0"
-    "@types/lodash" "^4.14.168"
-    babel-jest "26.3.0"
-    babel-loader "^8.2.2"
-    babel-plugin-emotion "^10.0.33"
-    babel-plugin-import "^1.13.3"
-    clean-webpack-plugin "^3.0.0"
-    convert-array-to-csv "^2.0.0"
-    css-loader "^5.1.3"
-    css-minimizer-webpack-plugin "^3.4.1"
-    dotenv "8.2.0"
-    dotenv-expand "5.1.0"
-    eslint "^7.10.0"
-    execa "^4.0.1"
-    file-loader "^6.2.0"
-    fs-extra "^9.0.0"
-    html-webpack-plugin "^5.1.0"
-    is-ci "^2.0.0"
-    jest "26.4.2"
-    jest-junit "^13.0.0"
-    jest-mock-process "^1.4.1"
-    license-webpack-plugin "^2.3.21"
-    lodash "^4.17.15"
-    mini-css-extract-plugin "^1.3.9"
-    node-fetch "^2.5.0"
-    pkg-dir "^4.1.0"
-    prettier "^2.0.5"
-    process "^0.11.10"
-    react-dev-utils "^11.0.2"
-    react-scripts "4.0.0-next.77"
-    resolve "^1.20.0"
-    rollup "^2.11.2"
-    rollup-plugin-postcss "^3.1.8"
-    serve "^13.0.2"
-    sort-package-json "^1.44.0"
-    style-loader "^3.3.1"
-    terser-webpack-plugin "5.1.1"
-    tslib "^2.0.0"
-    wait-on "^6.0.1"
-    webpack "^5.24.4"
-    webpack-cli "^4.5.0"
-    webpack-dev-server "^3.11.2"
-    webpack-manifest-plugin "^3.1.0"
-    yargs "^15.3.1"
-
-"@activeviam/activeui-sdk@5.0.15":
+"@activeviam/activeui-sdk-5.0@npm:@activeviam/activeui-sdk@5.0.15":
   version "5.0.15"
   resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/activeui-sdk/-/@activeviam/activeui-sdk-5.0.15.tgz#ebca8a0edd45b3517cbbbdbb0ddd7cd552de6e72"
   integrity sha512-ULEqYwaFmVzBqrScHCoMrvJZVfqulRQjlDwoEIKno040z2gugXKRda6wrtEXVTSSJvo60yhjP+fkr5q9GRnJmA==
@@ -211,6 +148,69 @@
     "@activeviam/widget" "5.0.15"
     "@activeviam/wizard" "5.0.15"
     "@types/fs-extra" "^9.0.1"
+
+"@activeviam/activeui-sdk-scripts@5.0.15":
+  version "5.0.15"
+  resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/activeui-sdk-scripts/-/@activeviam/activeui-sdk-scripts-5.0.15.tgz#d2aec0a31978c5fc21a38e91ea9d2dc1dc9dbd9a"
+  integrity sha512-wHozxUFqHMtWSbI2Ceu/f2QgT1arhtM0L4S/m5/DpU4pEhGXKDkoUzDO6Xtz14Jl4az4VQdTwgDgYyOH+QAO0g==
+  dependencies:
+    "@activeviam/content-server-initialization" "5.0.15"
+    "@babel/cli" "^7.11.6"
+    "@babel/core" "^7.12.16"
+    "@babel/plugin-proposal-class-properties" "^7.10.4"
+    "@babel/plugin-proposal-optional-chaining" "^7.11.0"
+    "@babel/plugin-transform-runtime" "^7.11.5"
+    "@babel/preset-env" "^7.12.16"
+    "@babel/preset-react" "^7.12.13"
+    "@babel/preset-typescript" "^7.12.16"
+    "@parcel/css" "^1.5.0"
+    "@rollup/plugin-babel" "^5.2.1"
+    "@rollup/plugin-commonjs" "^15.1.0"
+    "@rollup/plugin-json" "^4.1.0"
+    "@rollup/plugin-node-resolve" "^9.0.0"
+    "@types/lodash" "^4.14.168"
+    babel-jest "26.3.0"
+    babel-loader "^8.2.2"
+    babel-plugin-emotion "^10.0.33"
+    babel-plugin-import "^1.13.3"
+    clean-webpack-plugin "^3.0.0"
+    convert-array-to-csv "^2.0.0"
+    css-loader "^5.1.3"
+    css-minimizer-webpack-plugin "^3.4.1"
+    dotenv "8.2.0"
+    dotenv-expand "5.1.0"
+    eslint "^7.10.0"
+    execa "^4.0.1"
+    file-loader "^6.2.0"
+    fs-extra "^9.0.0"
+    html-webpack-plugin "^5.1.0"
+    is-ci "^2.0.0"
+    jest "26.4.2"
+    jest-junit "^13.0.0"
+    jest-mock-process "^1.4.1"
+    license-webpack-plugin "^2.3.21"
+    lodash "^4.17.15"
+    mini-css-extract-plugin "^1.3.9"
+    node-fetch "^2.5.0"
+    pkg-dir "^4.1.0"
+    prettier "^2.0.5"
+    process "^0.11.10"
+    react-dev-utils "^11.0.2"
+    react-scripts "4.0.0-next.77"
+    resolve "^1.20.0"
+    rollup "^2.11.2"
+    rollup-plugin-postcss "^3.1.8"
+    serve "^13.0.2"
+    sort-package-json "^1.44.0"
+    style-loader "^3.3.1"
+    terser-webpack-plugin "5.1.1"
+    tslib "^2.0.0"
+    wait-on "^6.0.1"
+    webpack "^5.24.4"
+    webpack-cli "^4.5.0"
+    webpack-dev-server "^3.11.2"
+    webpack-manifest-plugin "^3.1.0"
+    yargs "^15.3.1"
 
 "@activeviam/application-menu-about-menu-item@5.0.15":
   version "5.0.15"
@@ -394,7 +394,7 @@
     lodash "^4.17.15"
     tslib "^2.0.0"
 
-"@activeviam/content-server-initialization@5.0.15":
+"@activeviam/content-server-initialization-5.0@npm:@activeviam/content-server-initialization@5.0.15", "@activeviam/content-server-initialization@5.0.15":
   version "5.0.15"
   resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/content-server-initialization/-/@activeviam/content-server-initialization-5.0.15.tgz#cc8167f0b9f693f196cfbba3607de0cc6b8ffafd"
   integrity sha512-tHbbjnpfjYTFj+OWg7tEMIZtBrxIeYQAxIrSvONsNkrbYcGXr7mJP6sXPdBHxMiFZl+1fqHd3hdo6SuUofcN5A==
@@ -466,6 +466,15 @@
     react-error-boundary "^3.1.4"
     ts-essentials "^6.0.5"
 
+"@activeviam/data-model-5.0@npm:@activeviam/data-model@5.0.15", "@activeviam/data-model@5.0.15":
+  version "5.0.15"
+  resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/data-model/-/@activeviam/data-model-5.0.15.tgz#73122eb36a35b761bc6603ba6a3db99da47182d0"
+  integrity sha512-6V3EOWpgCorQ+QUFmmCEJx86r3hAjA0O4Tax0cM3ncvKfkj/f1Y3htB1bh/zeVqZiC5WlyIw5llEC5cu4FBRyA==
+  dependencies:
+    "@types/lodash" "^4.14.168"
+    lodash "^4.17.15"
+    ts-essentials "^6.0.5"
+
 "@activeviam/data-model-tree@5.0.15":
   version "5.0.15"
   resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/data-model-tree/-/@activeviam/data-model-tree-5.0.15.tgz#3ae123e90b11ad767bd1c168256ffe7ac8c7a492"
@@ -483,15 +492,6 @@
     "@types/lodash" "^4.14.168"
     "@types/react" "^16.9.34"
     lodash "^4.17.15"
-
-"@activeviam/data-model@5.0.15":
-  version "5.0.15"
-  resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/data-model/-/@activeviam/data-model-5.0.15.tgz#73122eb36a35b761bc6603ba6a3db99da47182d0"
-  integrity sha512-6V3EOWpgCorQ+QUFmmCEJx86r3hAjA0O4Tax0cM3ncvKfkj/f1Y3htB1bh/zeVqZiC5WlyIw5llEC5cu4FBRyA==
-  dependencies:
-    "@types/lodash" "^4.14.168"
-    lodash "^4.17.15"
-    ts-essentials "^6.0.5"
 
 "@activeviam/data-visualization@5.0.15":
   version "5.0.15"
@@ -658,17 +658,7 @@
     "@types/react" "^16.9.34"
     lodash "^4.17.15"
 
-"@activeviam/mdx-lexer@5.0.15":
-  version "5.0.15"
-  resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/mdx-lexer/-/@activeviam/mdx-lexer-5.0.15.tgz#dcc4e15e3140b5c898868899e69d726f50d25696"
-  integrity sha512-GXP0jLJD7VKAyc27ibYFpe0RECwtyVWl8v38MsQdJ/MjwuDqjRgxr1wwik1gpYRaetb5409Hk/qExsjo9ll1IQ==
-
-"@activeviam/mdx-parser@5.0.15":
-  version "5.0.15"
-  resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/mdx-parser/-/@activeviam/mdx-parser-5.0.15.tgz#c3553e5ba6b5110febfd241453c7c8cc279d9d09"
-  integrity sha512-sbmfIueqnItHAHKUMYT8aeAkPc4JIpU8/Es538yxqsVxoeRAcqVNXR/uV8YeZ0dUgcKRaY397UmJEcr0gpwPGA==
-
-"@activeviam/mdx@5.0.15":
+"@activeviam/mdx-5.0@npm:@activeviam/mdx@5.0.15", "@activeviam/mdx@5.0.15":
   version "5.0.15"
   resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/mdx/-/@activeviam/mdx-5.0.15.tgz#a54db8a7b961b7c6e197d1ca09f12223684b6d05"
   integrity sha512-b2jM8mQmKiKLV5B8sYx8wGlEbqF6Rvna9CB5v4j348RDXhXhhfNEv61IbEGbpQxKYM4VPd/AqGVa7OPC6Nqcqw==
@@ -680,6 +670,16 @@
     immer "^9.0.14"
     lodash "^4.17.15"
     utility-types "^3.10.0"
+
+"@activeviam/mdx-lexer@5.0.15":
+  version "5.0.15"
+  resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/mdx-lexer/-/@activeviam/mdx-lexer-5.0.15.tgz#dcc4e15e3140b5c898868899e69d726f50d25696"
+  integrity sha512-GXP0jLJD7VKAyc27ibYFpe0RECwtyVWl8v38MsQdJ/MjwuDqjRgxr1wwik1gpYRaetb5409Hk/qExsjo9ll1IQ==
+
+"@activeviam/mdx-parser@5.0.15":
+  version "5.0.15"
+  resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/mdx-parser/-/@activeviam/mdx-parser-5.0.15.tgz#c3553e5ba6b5110febfd241453c7c8cc279d9d09"
+  integrity sha512-sbmfIueqnItHAHKUMYT8aeAkPc4JIpU8/Es538yxqsVxoeRAcqVNXR/uV8YeZ0dUgcKRaY397UmJEcr0gpwPGA==
 
 "@activeviam/members-tree@5.0.15":
   version "5.0.15"


### PR DESCRIPTION
When migrating from 4.3 to 5.0, we want the target types to be taken from @activeviam/activeui-sdk-5.0.x.
When migrating from 5.0 to 5.1, we want the input types to be taken from @activeviam/activeui-sdk-5.0.x and the output types to be taken from @activeviam/activeui-sdk-5.1.y, so we need to depend on different versions of the SDK.

This PR introduces version aliases to allow us to use different versions of the same package. It changes the names of the `@activeviam` 5.0 packages currently in the `dependencies` in `package.json` to aliases, for example `"@activeviam/activeui-sdk"` becomes `"@activeviam/activeui-sdk-5.0"`.