### PR TITLE
UI-8014 - migrate_43_to_50 only accepts and mutates contentServer, counters and errorReport

### DIFF
--- a/src/4.3_to_5.0/migrate_43_to_50.test.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.test.ts
@@ -27,7 +27,7 @@ const hasRecord = (contentRecord: ContentRecord, recordId: string): boolean =>
 /**
  * Returns the content server root structure containing `uiFolder` and `pivotFolder`.
  */
-const getContentServerForUIFolder = (
+const getRootContentRecord = (
   uiFolder: ContentRecord,
   pivotFolder?: ContentRecord,
 ): ContentRecord => ({
@@ -69,7 +69,7 @@ describe("migrate_43_to_50", () => {
   });
 
   it("returns a valid ActiveUI5 /ui folder on a small input", async () => {
-    const contentServer = getContentServerForUIFolder(smallLegacyUIFolder);
+    const contentServer = getRootContentRecord(smallLegacyUIFolder);
     await migrate_43_to_50(contentServer, {
       errorReport,
       counters,
@@ -83,7 +83,7 @@ describe("migrate_43_to_50", () => {
   });
 
   it("returns a valid ActiveUI5 /ui folder on a real life input", async () => {
-    const contentServer = getContentServerForUIFolder(legacyUIFolder);
+    const contentServer = getRootContentRecord(legacyUIFolder);
     await migrate_43_to_50(contentServer, {
       errorReport,
       counters,
@@ -97,7 +97,7 @@ describe("migrate_43_to_50", () => {
   });
 
   it("returns a valid ActiveUI5 /ui folder that includes calculated measures when the input includes a pivotFolder", async () => {
-    const contentServer = getContentServerForUIFolder(
+    const contentServer = getRootContentRecord(
       legacyUIFolder,
       smallLegacyPivotFolder,
     );
@@ -116,7 +116,7 @@ describe("migrate_43_to_50", () => {
   });
 
   it("removes the specified widget plugins from the widget bookmarks themselves, and from the content of the dashboard bookmarks", async () => {
-    const contentServer = getContentServerForUIFolder(legacyUIFolder);
+    const contentServer = getRootContentRecord(legacyUIFolder);
     const keysOfWidgetPluginsToRemove = ["filters"];
     migrate_43_to_50(contentServer, {
       errorReport,
@@ -181,7 +181,7 @@ describe("migrate_43_to_50", () => {
   });
 
   it("returns an error report for dashboards and handles the dashboard id being a number", async () => {
-    const contentServer = getContentServerForUIFolder(
+    const contentServer = getRootContentRecord(
       smallLegacyUIFolderWithInvalidDashboard,
     );
     await migrate_43_to_50(contentServer, {
@@ -245,7 +245,7 @@ describe("migrate_43_to_50", () => {
   });
 
   it("copies invalid filters as-is and reports an error", async () => {
-    const contentServer = getContentServerForUIFolder(
+    const contentServer = getRootContentRecord(
       smallLegacyUIFolderWithInvalidFilter,
     );
     await migrate_43_to_50(contentServer, {

--- a/src/4.3_to_5.0/migrate_43_to_50.test.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.test.ts
@@ -1,11 +1,16 @@
 import _map from "lodash/map";
 import _some from "lodash/some";
+import _fromPairs from "lodash/fromPairs";
 import { migrate_43_to_50 } from "./migrate_43_to_50";
 import { smallLegacyUIFolder } from "./__test_resources__/smallLegacyUIFolder";
 import { legacyUIFolder } from "./__test_resources__/legacyUIFolder";
 import { servers } from "./__test_resources__/servers";
 import { ContentRecord } from "@activeviam/activeui-sdk-5.0";
-import { LegacyDashboardState } from "./migration.types";
+import {
+  ErrorReport,
+  LegacyDashboardState,
+  OutcomeCounters,
+} from "./migration.types";
 import { smallLegacyPivotFolder } from "./__test_resources__/smallLegacyPivotFolder";
 import { smallLegacyUIFolderWithInvalidFilter } from "./__test_resources__/smallLegacyUIFolderWithInvalidFilter";
 import { smallLegacyUIFolderWithInvalidDashboard } from "./__test_resources__/smallLegacyUIFolderWithInvalidDashboard";
@@ -19,6 +24,17 @@ const hasRecord = (contentRecord: ContentRecord, recordId: string): boolean =>
     (child, childId) => childId === recordId || hasRecord(child, recordId),
   );
 
+/**
+ * Returns the content server root structure containing `uiFolder` and `pivotFolder`.
+ */
+const getContentServerForUIFolder = (
+  uiFolder: ContentRecord,
+  pivotFolder?: ContentRecord,
+): ContentRecord => ({
+  children: { ui: uiFolder, ...(pivotFolder ? { pivot: pivotFolder } : {}) },
+  entry: { owners: [], readers: [] },
+});
+
 jest.mock(`./generateId`, () => {
   let counter = 0;
   return {
@@ -31,49 +47,80 @@ jest.mock(`./generateId`, () => {
   };
 });
 
+let errorReport: ErrorReport;
+let counters: OutcomeCounters;
+
 describe("migrate_43_to_50", () => {
+  beforeEach(() => {
+    errorReport = {};
+    counters = _fromPairs(
+      ["dashboards", "widgets", "filters", "folders"].map((type) => [
+        type,
+        {
+          success: 0,
+          partial: 0,
+          failed: 0,
+          removed: 0,
+        },
+      ]),
+      // _fromPairs returns a Dictionary.
+      // In this case, the keys used correspond to the attributes of OutcomeCounters.
+    ) as OutcomeCounters;
+  });
+
   it("returns a valid ActiveUI5 /ui folder on a small input", async () => {
-    const [migratedUIFolder, counters, errorReport] = await migrate_43_to_50(
-      smallLegacyUIFolder,
-      {
-        servers,
-        doesReportIncludeStacks: false,
-      },
-    );
+    const contentServer = getContentServerForUIFolder(smallLegacyUIFolder);
+    await migrate_43_to_50(contentServer, {
+      errorReport,
+      counters,
+      servers,
+      doesReportIncludeStacks: false,
+    });
+    const migratedUIFolder = contentServer.children?.ui;
     expect(migratedUIFolder).toMatchSnapshot();
-    expect(errorReport).toBeUndefined();
+    expect(errorReport).toEqual({});
     expect(counters).toMatchSnapshot();
   });
 
   it("returns a valid ActiveUI5 /ui folder on a real life input", async () => {
-    const [migratedUIFolder, counters, errorReport] = await migrate_43_to_50(
-      legacyUIFolder,
-      {
-        servers,
-        doesReportIncludeStacks: false,
-      },
-    );
+    const contentServer = getContentServerForUIFolder(legacyUIFolder);
+    await migrate_43_to_50(contentServer, {
+      errorReport,
+      counters,
+      servers,
+      doesReportIncludeStacks: false,
+    });
+    const migratedUIFolder = contentServer.children?.ui;
     expect(migratedUIFolder).toMatchSnapshot();
     expect(errorReport).toMatchSnapshot();
     expect(counters).toMatchSnapshot();
   });
 
   it("returns a valid ActiveUI5 /ui folder that includes calculated measures when the input includes a pivotFolder", async () => {
-    const [migratedUIFolder] = await migrate_43_to_50(legacyUIFolder, {
+    const contentServer = getContentServerForUIFolder(
+      legacyUIFolder,
+      smallLegacyPivotFolder,
+    );
+    await migrate_43_to_50(contentServer, {
+      errorReport,
+      counters,
       servers,
-      legacyPivotFolder: smallLegacyPivotFolder,
       doesReportIncludeStacks: false,
     });
 
+    const migratedUIFolder = contentServer.children?.ui;
     const calculatedMeasuresFolder =
-      migratedUIFolder.children?.["calculated_measures"];
+      migratedUIFolder?.children?.["calculated_measures"];
 
     expect(calculatedMeasuresFolder).toMatchSnapshot();
   });
 
   it("removes the specified widget plugins from the widget bookmarks themselves, and from the content of the dashboard bookmarks", async () => {
+    const contentServer = getContentServerForUIFolder(legacyUIFolder);
     const keysOfWidgetPluginsToRemove = ["filters"];
-    const [migratedUIFolder] = await migrate_43_to_50(legacyUIFolder, {
+    migrate_43_to_50(contentServer, {
+      errorReport,
+      counters,
       servers,
       keysOfWidgetPluginsToRemove,
       doesReportIncludeStacks: false,
@@ -83,7 +130,8 @@ describe("migrate_43_to_50", () => {
     // It is removed from the ActiveUI 5 UI folder.
     const savedContentInLegacyUIFolder: ContentRecord =
       legacyUIFolder.children!.bookmarks;
-    const savedWidgets = migratedUIFolder.children!.widgets;
+    const migratedUIFolder = contentServer.children?.ui;
+    const savedWidgets = migratedUIFolder!.children!.widgets;
     expect(hasRecord(savedContentInLegacyUIFolder, "0xb")).toBe(true);
     expect(hasRecord(savedWidgets, "0xb")).toBe(false);
 
@@ -100,7 +148,7 @@ describe("migrate_43_to_50", () => {
       ),
     );
     const migratedDashboard = JSON.parse(
-      migratedUIFolder.children!.dashboards.children!.content.children!.eef
+      migratedUIFolder!.children!.dashboards.children!.content.children!.eef
         .entry.content,
     );
     const { content, layout } = migratedDashboard.pages["p-0"];
@@ -133,16 +181,22 @@ describe("migrate_43_to_50", () => {
   });
 
   it("returns an error report for dashboards and handles the dashboard id being a number", async () => {
-    const [migratedFolder, counters, errorReport] = await migrate_43_to_50(
+    const contentServer = getContentServerForUIFolder(
       smallLegacyUIFolderWithInvalidDashboard,
-      {
-        servers,
-        doesReportIncludeStacks: false,
-      },
     );
+    await migrate_43_to_50(contentServer, {
+      errorReport,
+      counters,
+      servers,
+      doesReportIncludeStacks: false,
+    });
+
+    const migratedUIFolder = contentServer.children?.ui;
 
     expect(
-      migratedFolder.children?.dashboards?.children?.content?.children?.["158"],
+      migratedUIFolder?.children?.dashboards?.children?.content?.children?.[
+        "158"
+      ],
     ).toMatchInlineSnapshot(`
       Object {
         "entry": Object {
@@ -191,16 +245,19 @@ describe("migrate_43_to_50", () => {
   });
 
   it("copies invalid filters as-is and reports an error", async () => {
-    const [migratedFolder, counters, errorReport] = await migrate_43_to_50(
+    const contentServer = getContentServerForUIFolder(
       smallLegacyUIFolderWithInvalidFilter,
-      {
-        servers,
-        doesReportIncludeStacks: false,
-      },
     );
+    await migrate_43_to_50(contentServer, {
+      errorReport,
+      counters,
+      servers,
+      doesReportIncludeStacks: false,
+    });
 
+    const migratedUIFolder = contentServer.children?.ui;
     expect(
-      migratedFolder.children?.filters?.children?.content?.children?.["158"],
+      migratedUIFolder?.children?.filters?.children?.content?.children?.["158"],
     ).toMatchInlineSnapshot(`
       Object {
         "entry": Object {

--- a/src/4.3_to_5.0/migrate_43_to_50.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.ts
@@ -200,7 +200,7 @@ const accumulateStructure = ({
 };
 
 /**
- * Modifies the ActiveUI 4.3 `contentServer` structure, for it to be ready to be used by ActiveUI 5.0.
+ * Migrates `contentServer` from a version usable by ActiveUI 4.3 to one usable by ActiveUI 5.0.
  * Also keeps the number of migration successes and failures in `counters` and a detailed `errorReport`.
  *
  * Widgets with keys in `keysOfWidgetPluginsToRemove` are not migrated:

--- a/src/4.3_to_5.0/migrate_43_to_50.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.ts
@@ -227,7 +227,7 @@ export async function migrate_43_to_50(
 ): Promise<void> {
   if (contentServer.children?.ui === undefined) {
     throw new Error(
-      "Your content server structure doesn't contain any ui folder.",
+      "Your content server doesn't contain any /ui folder.",
     );
   }
 

--- a/src/4.3_to_5.0/migrate_43_to_50.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.ts
@@ -201,7 +201,7 @@ const accumulateStructure = ({
 
 /**
  * Migrates `contentServer` from a version usable by ActiveUI 4.3 to one usable by ActiveUI 5.0.
- * Also keeps the number of migration successes and failures in `counters` and a detailed `errorReport`.
+ * Also keeps track of the number of migration successes and failures in `counters` and a detailed `errorReport`.
  *
  * Widgets with keys in `keysOfWidgetPluginsToRemove` are not migrated:
  * - for a matching saved ActiveUI 4.3 widget, no ActiveUI 5.0 file is created.

--- a/src/4.3_to_5.0/migrate_43_to_50.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.ts
@@ -2,7 +2,6 @@ import _cloneDeep from "lodash/cloneDeep";
 import _set from "lodash/set";
 import _setWith from "lodash/setWith";
 import _omit from "lodash/omit";
-import _fromPairs from "lodash/fromPairs";
 
 import {
   ContentRecord,
@@ -201,42 +200,39 @@ const accumulateStructure = ({
 };
 
 /**
- * Returns the converted UI folder, ready to be used by ActiveUI 5.
- * Also returns a count of the number of migration successes and failures and an detailed error report.
+ * Modifies the ActiveUI 4.3 `contentServer` structure, for it to be ready to be used by ActiveUI 5.0.
+ * Also keeps the number of migration successes and failures in `counters` and a detailed `errorReport`.
  *
  * Widgets with keys in `keysOfWidgetPluginsToRemove` are not migrated:
- * - for a matching saved ActiveUI 4 widget, no ActiveUI 5 file is created.
- * - for a saved ActiveUI 4 dashboard including a matching widget, the widget is removed from the output ActiveUI 5 dashboard, and the layout is adapted so that siblings take the remaining space.
+ * - for a matching saved ActiveUI 4.3 widget, no ActiveUI 5.0 file is created.
+ * - for a saved ActiveUI 4.3 dashboard including a matching widget, the widget is removed from the output ActiveUI 5.0 dashboard, and the layout is adapted so that siblings take the remaining space.
+ *
+ * Mutates `contentServer`, `errorReport` and `counters`.
  */
 export async function migrate_43_to_50(
-  legacyUIFolder: ContentRecord,
+  contentServer: ContentRecord,
   {
+    errorReport,
+    counters,
     servers,
     keysOfWidgetPluginsToRemove,
-    legacyPivotFolder,
     doesReportIncludeStacks,
   }: {
+    errorReport: ErrorReport;
+    counters: OutcomeCounters;
     servers: { [serverKey: string]: { dataModel: DataModel; url: string } };
     keysOfWidgetPluginsToRemove?: string[];
     doesReportIncludeStacks: boolean;
-    legacyPivotFolder?: ContentRecord;
   },
-): Promise<[ContentRecord, OutcomeCounters, ErrorReport?]> {
+): Promise<void> {
+  if (contentServer.children?.ui === undefined) {
+    throw new Error(
+      "Your content server structure doesn't contain any ui folder.",
+    );
+  }
+
+  const legacyUIFolder = _cloneDeep(contentServer.children.ui);
   const migratedUIFolder: ContentRecord = _cloneDeep(emptyUIFolder);
-  const errorReport: ErrorReport = {};
-  const counters = _fromPairs(
-    ["dashboards", "widgets", "filters", "folders"].map((type) => [
-      type,
-      {
-        success: 0,
-        partial: 0,
-        failed: 0,
-        removed: 0,
-      },
-    ]),
-    // _fromPairs returns a Dictionary.
-    // In this case, the keys used correspond to the attributes of OutcomeCounters.
-  ) as OutcomeCounters;
 
   const dashboards: { [dashboardId: string]: any } = {};
   const widgets: { [widgetId: string]: any } = {};
@@ -504,6 +500,8 @@ export async function migrate_43_to_50(
     folders,
   });
 
+  const legacyPivotFolder = contentServer.children?.pivot;
+
   migratedUIFolder.children = {
     ...migratedUIFolder.children,
     ...(legacyPivotFolder
@@ -513,12 +511,8 @@ export async function migrate_43_to_50(
           ),
         }
       : {}),
-    ...migrateSettingsFolder(legacyUIFolder.children?.settings),
+    ...migrateSettingsFolder(legacyUIFolder?.children?.settings),
   };
 
-  return [
-    migratedUIFolder,
-    counters,
-    Object.keys(errorReport).length > 0 ? errorReport : undefined,
-  ];
+  contentServer.children.ui = migratedUIFolder;
 }

--- a/src/4.3_to_5.0/migrate_43_to_50.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.ts
@@ -226,9 +226,7 @@ export async function migrate_43_to_50(
   },
 ): Promise<void> {
   if (contentServer.children?.ui === undefined) {
-    throw new Error(
-      "Your content server doesn't contain any /ui folder.",
-    );
+    throw new Error("Your content server doesn't contain any /ui folder.");
   }
 
   const legacyUIFolder = _cloneDeep(contentServer.children.ui);

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -55,7 +55,7 @@ yargs
         alias: "i",
         type: "string",
         demandOption: true,
-        desc: "The path to the JSON export of the content root folder of the ActiveUI version to migrate from.",
+        desc: "The path to the JSON export of the Content Server to migrate.",
       });
       args.option("output-path", {
         alias: "o",

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -1,8 +1,11 @@
 import yargs from "yargs";
 import _capitalize from "lodash/capitalize";
+import _fromPairs from "lodash/fromPairs";
 import fs from "fs-extra";
 import { migrate_43_to_50 } from "../4.3_to_5.0/migrate_43_to_50";
 import path from "path";
+import { ErrorReport, OutcomeCounters } from "../4.3_to_5.0/migration.types";
+import { ContentRecord, DataModel } from "@activeviam/activeui-sdk-5.0";
 
 const summaryMessages: { [folderName: string]: { [outcome: string]: string } } =
   {
@@ -42,7 +45,6 @@ yargs
     outputPath: string;
     serversPath: string;
     removeWidgets: string[];
-    pivotInputPath?: string;
     debug: boolean;
     stack: boolean;
   }>(
@@ -53,13 +55,13 @@ yargs
         alias: "i",
         type: "string",
         demandOption: true,
-        desc: "The path to the JSON export of the ActiveUI 4 /ui folder.",
+        desc: "The path to the JSON export of the content root folder of the ActiveUI version to migrate from.",
       });
       args.option("output-path", {
         alias: "o",
         type: "string",
         demandOption: true,
-        desc: "The path to the migrated file, ready to be imported into the Content Server and used in ActiveUI 5.",
+        desc: "The path to the migrated file, ready to be imported into the Content Server and used in the ActiveUI version to migrate to.",
       });
       args.option("servers-path", {
         alias: "s",
@@ -71,12 +73,6 @@ yargs
         type: "array",
         demandOption: false,
         desc: "A list of keys of ActiveUI 4 widget plugins that should be removed during the migration.",
-      });
-      args.option("pivot-input-path", {
-        alias: "p",
-        type: "string",
-        demandOption: false,
-        desc: "The path to the JSON export of the /pivot folder on the content server.",
       });
       args.option("debug", {
         type: "boolean",
@@ -96,28 +92,40 @@ yargs
       outputPath,
       serversPath,
       removeWidgets: keysOfWidgetPluginsToRemove,
-      pivotInputPath,
       debug,
       stack,
     }) => {
-      const legacyUIFolder = await fs.readJSON(inputPath);
-      const legacyPivotFolder = pivotInputPath
-        ? await fs.readJSON(pivotInputPath)
-        : undefined;
-      const servers = await fs.readJSON(serversPath);
+      const contentServer: ContentRecord = await fs.readJSON(inputPath);
+      const servers: {
+        [serverKey: string]: { dataModel: DataModel; url: string };
+      } = await fs.readJSON(serversPath);
 
-      const [migratedUIFolder, counters, errorReport] = await migrate_43_to_50(
-        legacyUIFolder,
-        {
-          legacyPivotFolder,
-          servers,
-          keysOfWidgetPluginsToRemove,
-          doesReportIncludeStacks: stack,
-        },
-      );
+      const errorReport: ErrorReport = {};
+      const counters = _fromPairs(
+        ["dashboards", "widgets", "filters", "folders"].map((type) => [
+          type,
+          {
+            success: 0,
+            partial: 0,
+            failed: 0,
+            removed: 0,
+          },
+        ]),
+        // _fromPairs returns a Dictionary.
+        // In this case, the keys used correspond to the attributes of OutcomeCounters.
+      ) as OutcomeCounters;
+
+      await migrate_43_to_50(contentServer, {
+        errorReport,
+        counters,
+        servers,
+        keysOfWidgetPluginsToRemove,
+        doesReportIncludeStacks: stack,
+      });
 
       const { dir } = path.parse(outputPath);
 
+      const migratedUIFolder = contentServer.children?.ui;
       await fs.writeJSON(outputPath, migratedUIFolder, {
         spaces: 2,
       });

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -125,8 +125,7 @@ yargs
 
       const { dir } = path.parse(outputPath);
 
-      const migratedUIFolder = contentServer.children?.ui;
-      await fs.writeJSON(outputPath, migratedUIFolder, {
+      await fs.writeJSON(outputPath, contentServer, {
         spaces: 2,
       });
 


### PR DESCRIPTION
## Description

At the moment, `migrate_43_to_50` accepts `legacyUIFolder` as an argument, and returns the newly `migratedUIFolder`.
It also takes `legacyPivotFolder` as an argument.
It also creates and returns the `counters` and the `errorReport`.

For migration functions to be generically composable, a simpler design would be to have it:
* take the whole content server as an argument: no need for `legacyUIFolder` and `legacyPivotFolder` anymore
* mute the content server object inside the function
* accept `counters` and `errorReport` as arguments and mutate them inside
* return a `Promise<void>`