### PR TITLE
UI-7834 - Quick fix for `migrateCalculatedMeasures`

### DIFF
--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.test.ts
@@ -1,12 +1,12 @@
 import { migrateCalculatedMeasures } from "./migrateCalculatedMeasures";
-import { dataModelsForTests } from "@activeviam/data-model-5.0";
+import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 import { contentServer } from "../__test_resources__/contentServer";
 import { uiCalculatedMeasuresFolder } from "../__test_resources__/uiCalculatedMeasuresFolder";
 import { uiDashboardsFolder } from "../__test_resources__/uiDashboardsFolder";
 import { uiWidgetsFolder } from "../__test_resources__/uiWidgetsFolder";
 import _cloneDeep from "lodash/cloneDeep";
 
-const dataModel = dataModelsForTests.sandbox;
+const dataModel = sandboxDataModel;
 const contentServerForTests = _cloneDeep(contentServer);
 
 contentServerForTests.children!.ui.children = {

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.ts
@@ -1,10 +1,10 @@
 import {
   ContentRecord,
   CubeName,
-  DataModel,
   findContentRecords,
   getMetaData,
 } from "@activeviam/activeui-sdk-5.0";
+import { DataModel } from "@activeviam/activeui-sdk-5.1";
 import { migrateCalculatedMeasureContent } from "./migrateCalculatedMeasureContent";
 import { migrateCalculatedMeasuresInDashboards } from "./migrateCalculatedMeasuresInDashboards";
 import { migrateCalculatedMeasuresInWidgets } from "./migrateCalculatedMeasuresInWidgets";


### PR DESCRIPTION
Jira ticket : [UI-7834](https://support.activeviam.com/jira/browse/UI-7834)

In PR #57, certain files were changed to use the indexed version of the `DataModel` from 5.1. I hadn't merged the changes from that PR into #59 before merging, which has lead to type errors and failing unit tests. This PR fixes these problems.