### PR TITLE
UI-7645 - Support several servers when migrating calculated measures

### DIFF
--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.test.ts
@@ -6,7 +6,10 @@ import { uiDashboardsFolder } from "../__test_resources__/uiDashboardsFolder";
 import { uiWidgetsFolder } from "../__test_resources__/uiWidgetsFolder";
 import _cloneDeep from "lodash/cloneDeep";
 
-const dataModels = { "Ranch 6.0": sandboxDataModel };
+const dataModels = {
+  "Ranch 6.0": sandboxDataModel,
+  "Ranch 5.11": sandboxDataModel,
+};
 const contentServerForTests = _cloneDeep(contentServer);
 
 contentServerForTests.children!.ui.children = {

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.test.ts
@@ -6,7 +6,7 @@ import { uiDashboardsFolder } from "../__test_resources__/uiDashboardsFolder";
 import { uiWidgetsFolder } from "../__test_resources__/uiWidgetsFolder";
 import _cloneDeep from "lodash/cloneDeep";
 
-const dataModel = sandboxDataModel;
+const dataModels = { sandbox: sandboxDataModel };
 const contentServerForTests = _cloneDeep(contentServer);
 
 contentServerForTests.children!.ui.children = {
@@ -15,7 +15,7 @@ contentServerForTests.children!.ui.children = {
   dashboards: uiDashboardsFolder,
   widgets: uiWidgetsFolder,
 };
-migrateCalculatedMeasures(contentServerForTests, dataModel);
+migrateCalculatedMeasures(contentServerForTests, dataModels);
 
 describe("migrateCalculatedMeasures", () => {
   it("migrates the serialized definitions of all calculated measures created with ActiveUI 5.0 and used in a saved dashboard or saved widget, into ones that are natively supported by ActivePivot", () => {

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.test.ts
@@ -6,7 +6,7 @@ import { uiDashboardsFolder } from "../__test_resources__/uiDashboardsFolder";
 import { uiWidgetsFolder } from "../__test_resources__/uiWidgetsFolder";
 import _cloneDeep from "lodash/cloneDeep";
 
-const dataModels = { sandbox: sandboxDataModel };
+const dataModels = { "Ranch 6.0": sandboxDataModel };
 const contentServerForTests = _cloneDeep(contentServer);
 
 contentServerForTests.children!.ui.children = {

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasures.ts
@@ -35,8 +35,8 @@ const getCalculatedMeasureName = (
  */
 export function migrateCalculatedMeasures(
   contentServer: ContentRecord,
-  dataModel: DataModel,
-): any {
+  dataModels: { [serverKey: string]: DataModel },
+): void {
   const legacyCalculatedMeasuresFolder =
     contentServer.children?.ui.children?.calculated_measures;
   const cmFolder: ContentRecord | undefined =
@@ -61,7 +61,7 @@ export function migrateCalculatedMeasures(
     measureToCubeMapping: measureToCubeMappingInWidgets,
   } = migrateCalculatedMeasuresInWidgets(
     contentServer.children?.ui.children?.widgets!,
-    dataModel,
+    dataModels,
     namesOfCalculatedMeasuresToMigrate,
   );
 
@@ -70,7 +70,7 @@ export function migrateCalculatedMeasures(
     measureToCubeMapping: measureToCubeMappingInDashboards,
   } = migrateCalculatedMeasuresInDashboards(
     contentServer.children?.ui.children?.dashboards!,
-    dataModel,
+    dataModels,
     namesOfCalculatedMeasuresToMigrate,
   );
 

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInDashboards.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInDashboards.test.ts
@@ -2,7 +2,7 @@ import { uiDashboardsFolder } from "../__test_resources__/uiDashboardsFolder";
 import { migrateCalculatedMeasuresInDashboards } from "./migrateCalculatedMeasuresInDashboards";
 import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 
-const dataModel = sandboxDataModel;
+const dataModels = { sandbox: sandboxDataModel };
 
 // "pvSum ^ 2" is from cube "EquityDerivativesCubeDist", all others are from "EquityDerivativesCube".
 const calculatedMeasureNames = [
@@ -18,7 +18,7 @@ describe("migrateCalculatedMeasuresInDashboards", () => {
   const { migratedDashboards, measureToCubeMapping } =
     migrateCalculatedMeasuresInDashboards(
       uiDashboardsFolder,
-      dataModel,
+      dataModels,
       calculatedMeasureNames,
     );
 

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInDashboards.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInDashboards.test.ts
@@ -2,7 +2,7 @@ import { uiDashboardsFolder } from "../__test_resources__/uiDashboardsFolder";
 import { migrateCalculatedMeasuresInDashboards } from "./migrateCalculatedMeasuresInDashboards";
 import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 
-const dataModels = { sandbox: sandboxDataModel };
+const dataModels = { "Ranch 6.0": sandboxDataModel };
 
 // "pvSum ^ 2" is from cube "EquityDerivativesCubeDist", all others are from "EquityDerivativesCube".
 const calculatedMeasureNames = [

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInDashboards.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInDashboards.test.ts
@@ -2,7 +2,10 @@ import { uiDashboardsFolder } from "../__test_resources__/uiDashboardsFolder";
 import { migrateCalculatedMeasuresInDashboards } from "./migrateCalculatedMeasuresInDashboards";
 import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 
-const dataModels = { "Ranch 6.0": sandboxDataModel };
+const dataModels = {
+  "Ranch 6.0": sandboxDataModel,
+  "Ranch 5.11": sandboxDataModel,
+};
 
 // "pvSum ^ 2" is from cube "EquityDerivativesCubeDist", all others are from "EquityDerivativesCube".
 const calculatedMeasureNames = [

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInMdx.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInMdx.test.ts
@@ -90,7 +90,7 @@ const namesOfCalculatedMeasurestoMigrate = [
   "Test calculated measure",
 ];
 
-const dataModel = sandboxDataModel;
+const dataModels = { sandbox: sandboxDataModel };
 
 describe("migrateCalculatedMeasuresInMdx", () => {
   it("returns `namesOfCalculatedMeasuresToMigrateInWidget` as an empty array and does not modify the MDX when there are no calculated measures", () => {
@@ -98,11 +98,12 @@ describe("migrateCalculatedMeasuresInMdx", () => {
       cubeName,
       namesOfCalculatedMeasuresToMigrateInWidget,
       migratedMdx,
-    } = migrateCalculatedMeasuresInMdx(
-      mdxSelectWithNoCalculatedMeasures,
+    } = migrateCalculatedMeasuresInMdx({
+      mdx: mdxSelectWithNoCalculatedMeasures,
       namesOfCalculatedMeasurestoMigrate,
-      dataModel,
-    );
+      dataModels,
+      serverKey: "sandbox",
+    });
 
     expect(cubeName).toStrictEqual("EquityDerivativesCube");
     expect(namesOfCalculatedMeasuresToMigrateInWidget).toStrictEqual([]);
@@ -114,11 +115,12 @@ describe("migrateCalculatedMeasuresInMdx", () => {
       cubeName,
       namesOfCalculatedMeasuresToMigrateInWidget,
       migratedMdx,
-    } = migrateCalculatedMeasuresInMdx(
-      mdxSelectWithOneCalculatedMeasure,
+    } = migrateCalculatedMeasuresInMdx({
+      mdx: mdxSelectWithOneCalculatedMeasure,
       namesOfCalculatedMeasurestoMigrate,
-      dataModel,
-    );
+      dataModels,
+      serverKey: "sandbox",
+    });
 
     expect(cubeName).toStrictEqual("EquityDerivativesCube");
     expect(namesOfCalculatedMeasuresToMigrateInWidget).toStrictEqual([
@@ -151,11 +153,12 @@ describe("migrateCalculatedMeasuresInMdx", () => {
       cubeName,
       namesOfCalculatedMeasuresToMigrateInWidget,
       migratedMdx,
-    } = migrateCalculatedMeasuresInMdx(
-      mdxSelectWithTwoCalculatedMeasures,
+    } = migrateCalculatedMeasuresInMdx({
+      mdx: mdxSelectWithTwoCalculatedMeasures,
       namesOfCalculatedMeasurestoMigrate,
-      dataModel,
-    );
+      dataModels,
+      serverKey: "sandbox",
+    });
 
     expect(cubeName).toStrictEqual("EquityDerivativesCube");
     expect(namesOfCalculatedMeasuresToMigrateInWidget).toStrictEqual([
@@ -189,12 +192,13 @@ describe("migrateCalculatedMeasuresInMdx", () => {
       cubeName,
       namesOfCalculatedMeasuresToMigrateInWidget,
       migratedMdx,
-    } = migrateCalculatedMeasuresInMdx(
+    } = migrateCalculatedMeasuresInMdx({
       // mdxSelectWithCalculatedMeasureNotOnList contains [Measures].[pvSum ^ 2], which is not on the list of `namesOfCalculatedMeasurestoMigrate`.
-      mdxSelectWithCalculatedMeasureNotOnList,
+      mdx: mdxSelectWithCalculatedMeasureNotOnList,
       namesOfCalculatedMeasurestoMigrate,
-      dataModel,
-    );
+      dataModels,
+      serverKey: "sandbox",
+    });
 
     expect(cubeName).toStrictEqual("EquityDerivativesCubeDist");
     // No calculated measure names are returned.

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInMdx.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInMdx.test.ts
@@ -90,7 +90,7 @@ const namesOfCalculatedMeasurestoMigrate = [
   "Test calculated measure",
 ];
 
-const dataModels = { sandbox: sandboxDataModel };
+const dataModels = { "Ranch 6.0": sandboxDataModel };
 
 describe("migrateCalculatedMeasuresInMdx", () => {
   it("returns `namesOfCalculatedMeasuresToMigrateInWidget` as an empty array and does not modify the MDX when there are no calculated measures", () => {
@@ -102,7 +102,7 @@ describe("migrateCalculatedMeasuresInMdx", () => {
       mdx: mdxSelectWithNoCalculatedMeasures,
       namesOfCalculatedMeasurestoMigrate,
       dataModels,
-      serverKey: "sandbox",
+      serverKey: "Ranch 6.0",
     });
 
     expect(cubeName).toStrictEqual("EquityDerivativesCube");
@@ -119,7 +119,7 @@ describe("migrateCalculatedMeasuresInMdx", () => {
       mdx: mdxSelectWithOneCalculatedMeasure,
       namesOfCalculatedMeasurestoMigrate,
       dataModels,
-      serverKey: "sandbox",
+      serverKey: "Ranch 6.0",
     });
 
     expect(cubeName).toStrictEqual("EquityDerivativesCube");
@@ -157,7 +157,7 @@ describe("migrateCalculatedMeasuresInMdx", () => {
       mdx: mdxSelectWithTwoCalculatedMeasures,
       namesOfCalculatedMeasurestoMigrate,
       dataModels,
-      serverKey: "sandbox",
+      serverKey: "Ranch 6.0",
     });
 
     expect(cubeName).toStrictEqual("EquityDerivativesCube");
@@ -197,7 +197,7 @@ describe("migrateCalculatedMeasuresInMdx", () => {
       mdx: mdxSelectWithCalculatedMeasureNotOnList,
       namesOfCalculatedMeasurestoMigrate,
       dataModels,
-      serverKey: "sandbox",
+      serverKey: "Ranch 6.0",
     });
 
     expect(cubeName).toStrictEqual("EquityDerivativesCubeDist");

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInMdx.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInMdx.ts
@@ -1,25 +1,35 @@
-import { getCube, DataModel } from "@activeviam/activeui-sdk-5.1";
+import { DataModel, getTargetCube } from "@activeviam/activeui-sdk-5.1";
 import {
   CubeName,
   getCalculatedMeasures,
   getCubeName,
   MdxSelect,
+  MdxDrillthrough,
 } from "@activeviam/activeui-sdk-5.0";
-import { removeCalculatedMemberDefinition } from "@activeviam/mdx-5.1";
+import {
+  removeCalculatedMemberDefinition,
+  isMdxDrillthrough,
+} from "@activeviam/mdx-5.1";
 import _intersection from "lodash/intersection";
 
 /**
  * Removes the definitions of the calculated measures matching `namesOfCalculatedMeasuresToMigrate` from the `WITH` clause of `mdx`.
  * Returns the updated MDX, the names of those calculated measures, and the corresponding cube name.
  */
-export const migrateCalculatedMeasuresInMdx = (
-  mdx: MdxSelect,
-  namesOfCalculatedMeasurestoMigrate: string[],
-  dataModel: DataModel,
-): {
+export const migrateCalculatedMeasuresInMdx = ({
+  mdx,
+  serverKey,
+  dataModels,
+  namesOfCalculatedMeasurestoMigrate,
+}: {
+  mdx: MdxSelect | MdxDrillthrough;
+  serverKey?: string;
+  dataModels: { [serverKey: string]: DataModel };
+  namesOfCalculatedMeasurestoMigrate: string[];
+}): {
   cubeName: CubeName;
   namesOfCalculatedMeasuresToMigrateInWidget: string[];
-  migratedMdx: MdxSelect;
+  migratedMdx: MdxSelect | MdxDrillthrough;
 } => {
   const namesOfCalculatedMeasuresToMigrateInWidget = _intersection(
     Object.keys(getCalculatedMeasures(mdx)),
@@ -27,6 +37,9 @@ export const migrateCalculatedMeasuresInMdx = (
   );
 
   const cubeName = getCubeName(mdx);
+  const { cube } = getTargetCube({ dataModels, serverKey, cubeName });
+
+  const mdxSelect = isMdxDrillthrough(mdx) ? mdx.select : mdx;
 
   const updatedMdx = namesOfCalculatedMeasuresToMigrateInWidget.reduce(
     (acc, calculatedMeasureName) =>
@@ -34,14 +47,16 @@ export const migrateCalculatedMeasuresInMdx = (
         dimensionName: "Measures",
         hierarchyName: "Measures",
         calculatedMemberName: calculatedMeasureName,
-        cube: getCube(dataModel, cubeName),
+        cube,
       }),
-    mdx,
+    mdxSelect,
   );
 
   return {
     cubeName,
     namesOfCalculatedMeasuresToMigrateInWidget,
-    migratedMdx: updatedMdx,
+    migratedMdx: isMdxDrillthrough(mdx)
+      ? { ...mdx, select: updatedMdx }
+      : updatedMdx,
   };
 };

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInWidgets.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInWidgets.test.ts
@@ -2,7 +2,7 @@ import { migrateCalculatedMeasuresInWidgets } from "./migrateCalculatedMeasuresI
 import { uiWidgetsFolder } from "../__test_resources__/uiWidgetsFolder";
 import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 
-const dataModel = sandboxDataModel;
+const dataModels = { sandbox: sandboxDataModel };
 
 // "CM in 2 cubes" is used in widgets targeting "EquityDerivativesCube" or "EquityDerivativesCubeDist".
 // "pvSum ^ 2" is used in widgets targeting "EquityDerivativesCubeDist".
@@ -20,7 +20,7 @@ describe("migrateCalculatedMeasuresInWidgets", () => {
   const { measureToCubeMapping, migratedWidgetsRecord } =
     migrateCalculatedMeasuresInWidgets(
       uiWidgetsFolder,
-      dataModel,
+      dataModels,
       namesOfCalculatedMeasurestoMigrate,
     );
 

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInWidgets.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInWidgets.test.ts
@@ -2,7 +2,7 @@ import { migrateCalculatedMeasuresInWidgets } from "./migrateCalculatedMeasuresI
 import { uiWidgetsFolder } from "../__test_resources__/uiWidgetsFolder";
 import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 
-const dataModels = { sandbox: sandboxDataModel };
+const dataModels = { "Ranch 6.0": sandboxDataModel };
 
 // "CM in 2 cubes" is used in widgets targeting "EquityDerivativesCube" or "EquityDerivativesCubeDist".
 // "pvSum ^ 2" is used in widgets targeting "EquityDerivativesCubeDist".

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInWidgets.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInWidgets.test.ts
@@ -4,7 +4,7 @@ import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resourc
 
 const dataModels = {
   "Ranch 6.0": sandboxDataModel,
-  "Rancch 5.11": sandboxDataModel,
+  "Ranch 5.11": sandboxDataModel,
 };
 
 // "CM in 2 cubes" is used in widgets targeting "EquityDerivativesCube" or "EquityDerivativesCubeDist".

--- a/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInWidgets.test.ts
+++ b/src/5.0_to_5.1/calculated-measures/migrateCalculatedMeasuresInWidgets.test.ts
@@ -2,7 +2,10 @@ import { migrateCalculatedMeasuresInWidgets } from "./migrateCalculatedMeasuresI
 import { uiWidgetsFolder } from "../__test_resources__/uiWidgetsFolder";
 import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 
-const dataModels = { "Ranch 6.0": sandboxDataModel };
+const dataModels = {
+  "Ranch 6.0": sandboxDataModel,
+  "Rancch 5.11": sandboxDataModel,
+};
 
 // "CM in 2 cubes" is used in widgets targeting "EquityDerivativesCube" or "EquityDerivativesCubeDist".
 // "pvSum ^ 2" is used in widgets targeting "EquityDerivativesCubeDist".


### PR DESCRIPTION
Aligning on the other migration functions to use `dataModels` instead of `dataModel`.
Indeed, there can be several target ActivePivot servers.