### PR TITLE
UI-7645 - Handle corrupt content

### DIFF
--- a/src/4.3_to_5.0/migrate_43_to_50.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.ts
@@ -23,7 +23,7 @@ import cliProgress from "cli-progress";
 import { _addErrorToReport } from "../_addErrorToReport";
 import { emptyUIFolder } from "@activeviam/content-server-initialization-5.0";
 import { _getFolderName } from "./_getFolderName";
-import { _addCorruptFileToReport } from "../_addCorruptFileErrorToReport";
+import { _addCorruptFileErrorToReport } from "../_addCorruptFileErrorToReport";
 
 const _getFolder = (
   record: ContentRecord | undefined,
@@ -279,8 +279,8 @@ export async function migrate_43_to_50(
 
         counters[errorReportSection].removed++;
 
-        _addCorruptFileToReport(errorReport, {
-          // Folders have no content entry anyway.
+        _addCorruptFileErrorToReport(errorReport, {
+          // Folders have no content entry.
           contentType: errorReportSection as
             | "dashboards"
             | "widgets"

--- a/src/4.3_to_5.0/migrate_43_to_50.ts
+++ b/src/4.3_to_5.0/migrate_43_to_50.ts
@@ -1,5 +1,4 @@
 import _set from "lodash/set";
-import _setWith from "lodash/setWith";
 import _omit from "lodash/omit";
 import _cloneDeep from "lodash/cloneDeep";
 
@@ -24,6 +23,7 @@ import cliProgress from "cli-progress";
 import { _addErrorToReport } from "../_addErrorToReport";
 import { emptyUIFolder } from "@activeviam/content-server-initialization-5.0";
 import { _getFolderName } from "./_getFolderName";
+import { _addCorruptFileToReport } from "../_addCorruptFileErrorToReport";
 
 const _getFolder = (
   record: ContentRecord | undefined,
@@ -279,17 +279,16 @@ export async function migrate_43_to_50(
 
         counters[errorReportSection].removed++;
 
-        _setWith(
-          errorReport,
-          [errorReportSection, fileId],
-          {
-            name: bookmark.name,
-            error: {
-              message: "Could not find the entry in the structure folder.",
-            },
-          },
-          Object,
-        );
+        _addCorruptFileToReport(errorReport, {
+          // Folders have no content entry anyway.
+          contentType: errorReportSection as
+            | "dashboards"
+            | "widgets"
+            | "filters"
+            | "calculated_measures",
+          fileId,
+          name: bookmark.name,
+        });
       } else {
         const folderId = mapOfFolderIds[fileId];
         const folderName = _getFolderName(legacyContent, folderId);

--- a/src/_addCorruptFileErrorToReport.ts
+++ b/src/_addCorruptFileErrorToReport.ts
@@ -1,0 +1,33 @@
+import _setWith from "lodash/setWith";
+import { ErrorReport } from "./migration.types";
+
+/**
+ * Reports that no entry matching `fileId` was found in the `/ui/${contentType}/structure` folder.
+ */
+export function _addCorruptFileToReport(
+  errorReport: ErrorReport,
+  {
+    contentType,
+    fileId,
+    name,
+  }: {
+    contentType: "dashboards" | "widgets" | "filters" | "calculated_measures";
+    fileId: string;
+    name?: string;
+  },
+): void {
+  // `_set` would normally be used here, however `fileId` could be a numerical string that `_set` would interpret as an index in an array instead of an object key
+  // see https://github.com/lodash/lodash/issues/3414#issuecomment-334655702
+  // Using `_setWith` is the recommended workaround.
+  _setWith(
+    errorReport,
+    [contentType, fileId],
+    {
+      name,
+      error: {
+        message: `Content file /ui/${contentType}/content/${fileId} is corrupt as it does not have a matching file under /ui/${contentType}/structure.\n It will not be migrated.`,
+      },
+    },
+    Object,
+  );
+}

--- a/src/_addCorruptFileErrorToReport.ts
+++ b/src/_addCorruptFileErrorToReport.ts
@@ -4,7 +4,7 @@ import { ErrorReport } from "./migration.types";
 /**
  * Reports that no entry matching `fileId` was found in the `/ui/${contentType}/structure` folder.
  */
-export function _addCorruptFileToReport(
+export function _addCorruptFileErrorToReport(
   errorReport: ErrorReport,
   {
     contentType,

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -31,14 +31,14 @@ const summaryMessages: { [folderName: string]: { [outcome: string]: string } } =
       failed:
         "could not be migrated because errors occurred during their migration. They were copied as is into the migrated folder.",
       removed:
-        "were cleaned up because they could not be found in the ui/dashboards/structure folder. They were already not visible in ActiveUI 4.",
+        "were cleaned up because they could not be found in the ui/dashboards/structure folder. They were already not visible in your version of ActiveUI.",
     },
     filters: {
       success: "were successfully migrated.",
       failed:
         "could not be migrated because errors occurred during their migration. They were copied as is into the migrated folder.",
       removed:
-        "were cleaned up because they could not be found in the ui/filters/structure folder. They were already not visible in ActiveUI 4.",
+        "were cleaned up because they could not be found in the ui/filters/structure folder. They were already not visible in your version of ActiveUI.",
     },
     widgets: {
       success: "were successfully migrated.",
@@ -50,7 +50,7 @@ const summaryMessages: { [folderName: string]: { [outcome: string]: string } } =
     },
     folders: {
       removed:
-        "were cleaned up because they could not be found in their structure folder. They were already not visible in ActiveUI 4.",
+        "were cleaned up because they could not be found in their structure folder. They were already not visible in your version of ActiveUI.",
     },
     calculated_measures: {
       success: "were successfully migrated.",

--- a/src/getMigrateDashboards.ts
+++ b/src/getMigrateDashboards.ts
@@ -7,7 +7,7 @@ import {
   MigrateDashboardCallback,
   OutcomeCounters,
 } from "./migration.types";
-import { _addCorruptFileToReport } from "./_addCorruptFileErrorToReport";
+import { _addCorruptFileErrorToReport } from "./_addCorruptFileErrorToReport";
 import { _addErrorToReport } from "./_addErrorToReport";
 import { _addWidgetErrorToReport } from "./_addWidgetErrorToReport";
 import { _getFilesAncestry } from "./_getFilesAncestry";
@@ -63,7 +63,7 @@ export const getMigrateDashboards =
     for (const fileId in content.children) {
       if (!filesAncestry[fileId]) {
         counters.dashboards.removed++;
-        _addCorruptFileToReport(errorReport, {
+        _addCorruptFileErrorToReport(errorReport, {
           contentType: "dashboards",
           fileId,
         });

--- a/src/getMigrateDashboards.ts
+++ b/src/getMigrateDashboards.ts
@@ -7,6 +7,7 @@ import {
   MigrateDashboardCallback,
   OutcomeCounters,
 } from "./migration.types";
+import { _addCorruptFileToReport } from "./_addCorruptFileErrorToReport";
 import { _addErrorToReport } from "./_addErrorToReport";
 import { _addWidgetErrorToReport } from "./_addWidgetErrorToReport";
 import { _getFilesAncestry } from "./_getFilesAncestry";
@@ -60,6 +61,15 @@ export const getMigrateDashboards =
     const filesAncestry = _getFilesAncestry(structure);
 
     for (const fileId in content.children) {
+      if (!filesAncestry[fileId]) {
+        counters.dashboards.removed++;
+        _addCorruptFileToReport(errorReport, {
+          contentType: "dashboards",
+          fileId,
+        });
+        continue;
+      }
+
       const { entry } = content.children[fileId];
       const dashboard = JSON.parse(entry.content);
 

--- a/src/getMigrateSavedFilters.ts
+++ b/src/getMigrateSavedFilters.ts
@@ -6,6 +6,7 @@ import {
   MigrateFilterCallback,
   OutcomeCounters,
 } from "./migration.types";
+import { _addCorruptFileToReport } from "./_addCorruptFileErrorToReport";
 import { _addErrorToReport } from "./_addErrorToReport";
 import { _getFilesAncestry } from "./_getFilesAncestry";
 import { _getMetaData } from "./_getMetaData";
@@ -56,6 +57,15 @@ export const getMigrateSavedFilters =
     const filesAncestry = _getFilesAncestry(structure);
 
     for (const fileId in content.children) {
+      if (!filesAncestry[fileId]) {
+        counters.dashboards.removed++;
+        _addCorruptFileToReport(errorReport, {
+          contentType: "filters",
+          fileId,
+        });
+        continue;
+      }
+
       const { entry } = content.children[fileId];
       const filter = JSON.parse(entry.content);
 

--- a/src/getMigrateSavedFilters.ts
+++ b/src/getMigrateSavedFilters.ts
@@ -6,7 +6,7 @@ import {
   MigrateFilterCallback,
   OutcomeCounters,
 } from "./migration.types";
-import { _addCorruptFileToReport } from "./_addCorruptFileErrorToReport";
+import { _addCorruptFileErrorToReport } from "./_addCorruptFileErrorToReport";
 import { _addErrorToReport } from "./_addErrorToReport";
 import { _getFilesAncestry } from "./_getFilesAncestry";
 import { _getMetaData } from "./_getMetaData";
@@ -59,7 +59,7 @@ export const getMigrateSavedFilters =
     for (const fileId in content.children) {
       if (!filesAncestry[fileId]) {
         counters.dashboards.removed++;
-        _addCorruptFileToReport(errorReport, {
+        _addCorruptFileErrorToReport(errorReport, {
           contentType: "filters",
           fileId,
         });

--- a/src/getMigrateSavedWidgets.ts
+++ b/src/getMigrateSavedWidgets.ts
@@ -11,6 +11,7 @@ import { _getFilesAncestry } from "./_getFilesAncestry";
 import { _serializeError } from "./_serializeError";
 import { _getMetaData } from "./_getMetaData";
 import { produce } from "immer";
+import { _addCorruptFileToReport } from "./_addCorruptFileErrorToReport";
 
 /**
  * Returns a function which can be called to migrate ActiveUI 5+ widgets.
@@ -59,6 +60,15 @@ export const getMigrateSavedWidgets =
     const filesAncestry = _getFilesAncestry(structure);
 
     for (const fileId in content.children) {
+      if (!filesAncestry[fileId]) {
+        counters.dashboards.removed++;
+        _addCorruptFileToReport(errorReport, {
+          contentType: "widgets",
+          fileId,
+        });
+        continue;
+      }
+
       const { entry } = content.children[fileId];
       const widget = JSON.parse(entry.content);
 

--- a/src/getMigrateSavedWidgets.ts
+++ b/src/getMigrateSavedWidgets.ts
@@ -11,7 +11,7 @@ import { _getFilesAncestry } from "./_getFilesAncestry";
 import { _serializeError } from "./_serializeError";
 import { _getMetaData } from "./_getMetaData";
 import { produce } from "immer";
-import { _addCorruptFileToReport } from "./_addCorruptFileErrorToReport";
+import { _addCorruptFileErrorToReport } from "./_addCorruptFileErrorToReport";
 
 /**
  * Returns a function which can be called to migrate ActiveUI 5+ widgets.
@@ -62,7 +62,7 @@ export const getMigrateSavedWidgets =
     for (const fileId in content.children) {
       if (!filesAncestry[fileId]) {
         counters.dashboards.removed++;
-        _addCorruptFileToReport(errorReport, {
+        _addCorruptFileErrorToReport(errorReport, {
           contentType: "widgets",
           fileId,
         });


### PR DESCRIPTION
We were properly handling corrupt content (= saved content for which there is a file in `content` but no matching file(s) in `structure`) for the migration from 4.3 to 5.0, but not for the new migration functions.
This PR adds this handling.