### PR TITLE
UI-7645 - Refactor types for extra migration callback args

### DIFF
--- a/src/5.0_to_5.1/migrateDashboard.ts
+++ b/src/5.0_to_5.1/migrateDashboard.ts
@@ -1,43 +1,33 @@
 import { DashboardState as DashboardState50 } from "@activeviam/activeui-sdk-5.0";
-import { DataModel } from "@activeviam/activeui-sdk-5.1";
+import { DashboardState as DashboardState51 } from "@activeviam/activeui-sdk-5.1";
 import _forEach from "lodash/forEach";
 import { migrateWidgetsWithinDashboard } from "../migrateWidgetsWithinDashboard";
+import { MigrateDashboardCallback } from "../migration.types";
 import { migrateContextValues } from "./migrateContextValues";
 import { migrateFilters } from "./migrateFilters";
 import { migrateWidget } from "./migrateWidget";
 
 /**
  * Mutates a 5.0 `dashboardState` into one usable in 5.1.
+ * Also mutates `measureToCubeMapping`.
  */
-export const migrateDashboard = (
-  dashboardState: DashboardState50,
+export const migrateDashboard: MigrateDashboardCallback<
+  DashboardState50,
+  DashboardState51,
+  {
+    namesOfCalculatedMeasuresToMigrate: string[];
+    measureToCubeMapping: { [measureName: string]: string[] };
+  }
+> = (
+  dashboardState,
   {
     dataModels,
     keysOfWidgetPluginsToRemove,
     onErrorWhileMigratingWidget,
     namesOfCalculatedMeasuresToMigrate,
     measureToCubeMapping,
-  }: {
-    dataModels: { [serverKey: string]: DataModel };
-    keysOfWidgetPluginsToRemove: string[];
-    onErrorWhileMigratingWidget: (
-      error: unknown,
-      {
-        pageKey,
-        leafKey,
-        pageName,
-        widgetName,
-      }: {
-        pageKey: string;
-        leafKey: string;
-        pageName: string;
-        widgetName: string;
-      },
-    ) => void;
-    namesOfCalculatedMeasuresToMigrate: string[];
-    measureToCubeMapping: { [measureName: string]: string[] };
   },
-): void => {
+) => {
   migrateFilters(dashboardState.filters);
   migrateContextValues(dashboardState.queryContext);
 

--- a/src/5.0_to_5.1/migrateWidget.ts
+++ b/src/5.0_to_5.1/migrateWidget.ts
@@ -1,24 +1,25 @@
 import { AWidgetState as AWidgetState50 } from "@activeviam/activeui-sdk-5.0";
-import { DataModel } from "@activeviam/activeui-sdk-5.1";
+import { AWidgetState as AWidgetState51 } from "@activeviam/activeui-sdk-5.1";
+import { MigrateWidgetCallback } from "../migration.types";
 import { migrateCalculatedMeasuresInWidget } from "./calculated-measures/migrateCalculatedMeasuresInWidget";
 import { migrateContextValues } from "./migrateContextValues";
 import { migrateFilters } from "./migrateFilters";
 
 /**
  * Mutates a 5.0 `widgetState` into one usable in 5.1.
+ * Also mutates `measureToCubeMapping`.
  */
-export const migrateWidget = (
-  widgetState: AWidgetState50,
+export const migrateWidget: MigrateWidgetCallback<
+  AWidgetState50,
+  AWidgetState51,
   {
-    dataModels,
-    namesOfCalculatedMeasuresToMigrate,
-    measureToCubeMapping,
-  }: {
-    dataModels: { [serverKey: string]: DataModel };
     namesOfCalculatedMeasuresToMigrate: string[];
     measureToCubeMapping: { [measureName: string]: string[] };
-  },
-): void => {
+  }
+> = (
+  widgetState,
+  { dataModels, namesOfCalculatedMeasuresToMigrate, measureToCubeMapping },
+) => {
   migrateCalculatedMeasuresInWidget(widgetState, {
     dataModels,
     namesOfCalculatedMeasuresToMigrate,

--- a/src/5.0_to_5.1/migrate_5.0_to_5.1.ts
+++ b/src/5.0_to_5.1/migrate_5.0_to_5.1.ts
@@ -1,12 +1,12 @@
 import {
-  deserializeWidgetState,
-  deserializeDashboardState,
   parse,
+  deserializeDashboardState,
+  deserializeWidgetState,
 } from "@activeviam/activeui-sdk-5.0";
 import {
+  stringify,
   serializeWidgetState,
   serializeDashboardState,
-  stringify,
 } from "@activeviam/activeui-sdk-5.1";
 import { MigrationFunction } from "../migration.types";
 import { migrateDashboard } from "./migrateDashboard";
@@ -21,6 +21,7 @@ export const migrate_50_to_51: MigrationFunction = (
     migrateDashboards,
     migrateSavedWidgets,
     migrateSavedFilters,
+    dataModels,
     errorReport,
     counters,
     doesReportIncludeStacks,
@@ -35,22 +36,21 @@ export const migrate_50_to_51: MigrationFunction = (
     deserializeDashboardState,
     (
       dashboardState,
-      { dataModels, keysOfWidgetPluginsToRemove, onErrorWhileMigratingWidget },
-    ) => {
+      { keysOfWidgetPluginsToRemove, onErrorWhileMigratingWidget },
+    ) =>
       migrateDashboard(dashboardState, {
         dataModels,
         keysOfWidgetPluginsToRemove,
         onErrorWhileMigratingWidget,
         namesOfCalculatedMeasuresToMigrate,
         measureToCubeMapping,
-      });
-    },
+      }),
     serializeDashboardState,
   );
 
   migrateSavedWidgets(
     deserializeWidgetState,
-    (widgetState, { dataModels }) =>
+    (widgetState) =>
       migrateWidget(widgetState, {
         dataModels,
         namesOfCalculatedMeasuresToMigrate,
@@ -59,6 +59,7 @@ export const migrate_50_to_51: MigrationFunction = (
     serializeWidgetState,
   );
 
+  // Must be called after `migrateDashboards` and `migrateSavedWidgets`, as `measureToCubeMapping` is accumulated during those steps.
   migrateSavedCalculatedMeasures({
     contentServer,
     measureToCubeMapping,

--- a/src/migration.types.ts
+++ b/src/migration.types.ts
@@ -85,13 +85,13 @@ export interface ErrorReport {
  * A function that can be called to migrate a dashboard from one version to another.
  * It is called within {@link produce | https://immerjs.github.io/immer/produce}, so it can safely mutate its input `dashboardState`.
  */
-export type MigrateDashboardCallback<FromDashboardState, ToDashboardState> = (
+export type MigrateDashboardCallback<
+  FromDashboardState,
+  ToDashboardState,
+  Options extends Record<string, unknown> = Record<string, unknown>,
+> = (
   dashboardState: FromDashboardState,
-  {
-    dataModels,
-    keysOfWidgetPluginsToRemove,
-    onErrorWhileMigratingWidget,
-  }: {
+  args: {
     dataModels: { [serverKey: string]: DataModel };
     keysOfWidgetPluginsToRemove: string[];
     onErrorWhileMigratingWidget: (
@@ -108,33 +108,37 @@ export type MigrateDashboardCallback<FromDashboardState, ToDashboardState> = (
         widgetName: string;
       },
     ) => void;
-  },
-) => ToDashboardState | void;
+  } & Options,
+) => void | ToDashboardState;
 
 /**
  * A function that can be called to migrate a widget from one version to another.
  */
-export type MigrateWidgetCallback<FromWidgetState, ToWidgetState> = (
+export type MigrateWidgetCallback<
+  FromWidgetState,
+  ToWidgetState,
+  Options extends Record<string, unknown> = Record<string, unknown>,
+> = (
   widgetState: FromWidgetState,
-  {
-    dataModels,
-  }: {
+  args: {
     dataModels: { [serverKey: string]: DataModel };
-  },
-) => ToWidgetState | void;
+  } & Options,
+) => void | ToWidgetState;
 
 /**
  * A function that can be called to migrate a filter from one version to another.
  * It is called within {@link produce | https://immerjs.github.io/immer/produce}, so it can safely mutate its input `filterState`.
  */
-export type MigrateFilterCallback<FromFilterState, ToFilterState> = (
+export type MigrateFilterCallback<
+  FromFilterState,
+  ToFilterState,
+  Options extends Record<string, unknown> = Record<string, unknown>,
+> = (
   filterState: FromFilterState,
-  {
-    dataModels,
-  }: {
+  args: {
     dataModels: { [serverKey: string]: DataModel };
-  },
-) => ToFilterState | void;
+  } & Options,
+) => void | ToFilterState;
 
 export type MigrationFunction<
   FromSerializedDashboardState = any,


### PR DESCRIPTION
Adding an extra `Options` generic for the migration callbacks, representing the extra options that one specific migration function might have.
For example `namesOfCalculatedMeasuresToMigrate` is necessary for the dashboard/widget migration callback of 5.0 to 5.1, but it most likely won't be for 5.1 to 5.2.
Doing it this way allows to assign `MigrateXyzCallback` to some variables while still keep the factorization for the other common args (e.g. `dataModels`) 