### PR TITLE
UI-7645 - Filters migration

### DIFF
--- a/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
+++ b/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
@@ -23,7 +23,7 @@ export function createFilterWithFirstMatchingCube(
   }
 
   throw new Error(
-    `The following MDX does not represent a filter: ${stringify(mdx, {
+    `No cube contains the hierarchies expressed in the following filter MDX: ${stringify(mdx, {
       indent: true,
     })}`,
   );

--- a/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
+++ b/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
@@ -15,7 +15,6 @@ export function createFilterWithFirstMatchingCube(
 ): Filter {
   for (const cube of cubes) {
     try {
-      console.log(cube)
       return createFilter(mdx, cube);
     } catch (e) {
       // The filter creation might be successful with another cube.

--- a/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
+++ b/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
@@ -7,7 +7,7 @@ import {
 } from "@activeviam/activeui-sdk-5.1";
 
 /**
- * Returns a {@link Filter} based on the input `mdx`, with the first matching cube.
+ * Returns a {@link Filter} based on `mdx`, with the first cube containing the hierarchies expressed in the MDX expression.
  */
 export function createFilterWithFirstMatchingCube(
   mdx: MdxExpression,

--- a/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
+++ b/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
@@ -7,7 +7,7 @@ import {
 } from "@activeviam/activeui-sdk-5.1";
 
 /**
- * Returns a {@link Filter} based on `mdx`, with the first cube containing the hierarchies expressed in the MDX expression.
+ * Returns a {@link Filter} based on `mdx`, with the first cube containing the hierarchies expressed in `mdx`.
  */
 export function createFilterWithFirstMatchingCube(
   mdx: MdxExpression,

--- a/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
+++ b/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
@@ -15,6 +15,7 @@ export function createFilterWithFirstMatchingCube(
 ): Filter {
   for (const cube of cubes) {
     try {
+      console.log(cube)
       return createFilter(mdx, cube);
     } catch (e) {
       // The filter creation might be successful with another cube.
@@ -23,6 +24,8 @@ export function createFilterWithFirstMatchingCube(
   }
 
   throw new Error(
-    `The following MDX does not represent a filter: ${stringify(mdx)}`,
+    `The following MDX does not represent a filter: ${stringify(mdx, {
+      indent: true,
+    })}`,
   );
 }

--- a/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
+++ b/src/5.0_to_5.1/createFilterWithFirstMatchingCube.ts
@@ -23,8 +23,11 @@ export function createFilterWithFirstMatchingCube(
   }
 
   throw new Error(
-    `No cube contains the hierarchies expressed in the following filter MDX: ${stringify(mdx, {
-      indent: true,
-    })}`,
+    `No cube contains the hierarchies expressed in the following filter MDX: ${stringify(
+      mdx,
+      {
+        indent: true,
+      },
+    )}`,
   );
 }

--- a/src/5.0_to_5.1/createFilterWithFirstMatchingDataModel.ts
+++ b/src/5.0_to_5.1/createFilterWithFirstMatchingDataModel.ts
@@ -1,0 +1,28 @@
+import { stringify } from "@activeviam/activeui-sdk-5.0";
+import {
+  createFilter,
+  MdxExpression,
+  Filter,
+  Cube,
+} from "@activeviam/activeui-sdk-5.1";
+
+/**
+ * Returns a {@link Filter} based on the input `mdx`, with the first matching cube.
+ */
+export function createFilterWithFirstMatchingCube(
+  mdx: MdxExpression,
+  cubes: Cube[],
+): Filter {
+  for (const cube of cubes) {
+    try {
+      return createFilter(mdx, cube);
+    } catch (e) {
+      // The filter creation might be successful with another cube.
+      // Continue.
+    }
+  }
+
+  throw new Error(
+    `The following MDX does not represent a filter: ${stringify(mdx)}`,
+  );
+}

--- a/src/5.0_to_5.1/getAllCubes.ts
+++ b/src/5.0_to_5.1/getAllCubes.ts
@@ -1,0 +1,13 @@
+import _flatMap from "lodash/flatMap";
+import { Cube, DataModel } from "@activeviam/activeui-sdk-5.1";
+
+/**
+ * Returns a flat list of all the cubes in the input `dataModels`.
+ */
+export function getAllCubes(dataModels: {
+  [serverKey: string]: DataModel;
+}): Cube[] {
+  return _flatMap(dataModels, (dataModel) =>
+    _flatMap(dataModel.catalogs, (catalog) => Object.values(catalog.cubes)),
+  );
+}

--- a/src/5.0_to_5.1/migrateDashboard.ts
+++ b/src/5.0_to_5.1/migrateDashboard.ts
@@ -28,11 +28,11 @@ export const migrateDashboard: MigrateDashboardCallback<
     measureToCubeMapping,
   },
 ) => {
-  migrateFilters(dashboardState.filters);
+  migrateFilters(dashboardState.filters, { dataModels });
   migrateContextValues(dashboardState.queryContext);
 
   _forEach(dashboardState.pages, (pageState) => {
-    migrateFilters(pageState.filters);
+    migrateFilters(pageState.filters, { dataModels });
     migrateContextValues(pageState.queryContext);
   });
 

--- a/src/5.0_to_5.1/migrateFilters.test.ts
+++ b/src/5.0_to_5.1/migrateFilters.test.ts
@@ -71,7 +71,7 @@ describe("migrateFilters", () => {
 
   it("throws if there is no cube containing the hierarchies expressed in Filter", () => {
     const squirtle = "[Pokemon].[Water].[ALL].[AllMember].[Squirtle]";
-    const filters = [squirtle].map(parse);
+    const filters = [parse(squirtle)];
     expect(() => {
       migrateFilters(filters, {
         dataModels,

--- a/src/5.0_to_5.1/migrateFilters.test.ts
+++ b/src/5.0_to_5.1/migrateFilters.test.ts
@@ -1,12 +1,15 @@
 import { parse, stringify } from "@activeviam/activeui-sdk-5.0";
+import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 import { migrateFilters } from "./migrateFilters";
+
+const dataModels = { sandbox: sandboxDataModel };
 
 describe("migrateFilters", () => {
   it("wraps the MDX representing each filter", () => {
     const euroAsString = "[Currency].[Currency].[ALL].[AllMember].[EUR]";
     const euro = parse(euroAsString);
     const filters = [euro];
-    migrateFilters(filters);
+    migrateFilters(filters, { dataModels });
     expect(filters).toHaveLength(1);
     // @ts-expect-error The point of the migration is to mutate the filters from `mdx` to `{mdx}`.
     expect(stringify(filters[0].mdx)).toBe(euroAsString);

--- a/src/5.0_to_5.1/migrateFilters.test.ts
+++ b/src/5.0_to_5.1/migrateFilters.test.ts
@@ -11,7 +11,7 @@ const dataModels = {
 };
 
 describe("migrateFilters", () => {
-  it("transforms each MdxExpression into a Filter", () => {
+  it("transforms each MdxExpression into a Filter, with the first cube containing the hierarchies expressed in the MDX expression", () => {
     const euro = "[Currency].[Currency].[ALL].[AllMember].[EUR]";
     const berlin = "[Geography].[City].[ALL].[AllMember].[Berlin]";
     const filters = [euro, berlin].map(parse);

--- a/src/5.0_to_5.1/migrateFilters.test.ts
+++ b/src/5.0_to_5.1/migrateFilters.test.ts
@@ -44,7 +44,7 @@ describe("migrateFilters", () => {
     `);
   });
 
-  it("uses the target cube identified by `cubeName` to create a Filter", () => {
+  it("transforms each MdxExpression into a Filter, with the target cube identified by `cubeName`", () => {
     const berlin = "[Geography].[City].[ALL].[AllMember].[Berlin]";
     const filters = [berlin].map(parse);
     migrateFilters(filters, {

--- a/src/5.0_to_5.1/migrateFilters.test.ts
+++ b/src/5.0_to_5.1/migrateFilters.test.ts
@@ -1,17 +1,40 @@
-import { parse, stringify } from "@activeviam/activeui-sdk-5.0";
+import { parse } from "@activeviam/activeui-sdk-5.0";
 import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
 import { migrateFilters } from "./migrateFilters";
 
 const dataModels = { sandbox: sandboxDataModel };
 
 describe("migrateFilters", () => {
-  it("wraps the MDX representing each filter", () => {
-    const euroAsString = "[Currency].[Currency].[ALL].[AllMember].[EUR]";
-    const euro = parse(euroAsString);
-    const filters = [euro];
+  it("transforms each MdxExpression into a Filter", () => {
+    const euro = "[Currency].[Currency].[ALL].[AllMember].[EUR]";
+    const berlin = "[Geography].[City].[ALL].[AllMember].[Berlin]";
+    const filters = [euro, berlin].map(parse);
     migrateFilters(filters, { dataModels });
-    expect(filters).toHaveLength(1);
-    // @ts-expect-error The point of the migration is to mutate the filters from `mdx` to `{mdx}`.
-    expect(stringify(filters[0].mdx)).toBe(euroAsString);
+    expect(filters).toMatchInlineSnapshot(`
+      [
+        {
+          "dimensionName": "Currency",
+          "hierarchyName": "Currency",
+          "members": [
+            [
+              "AllMember",
+              "EUR",
+            ],
+          ],
+          "type": "members",
+        },
+        {
+          "dimensionName": "Geography",
+          "hierarchyName": "City",
+          "members": [
+            [
+              "AllMember",
+              "Berlin",
+            ],
+          ],
+          "type": "members",
+        },
+      ]
+    `);
   });
 });

--- a/src/5.0_to_5.1/migrateFilters.test.ts
+++ b/src/5.0_to_5.1/migrateFilters.test.ts
@@ -77,7 +77,7 @@ describe("migrateFilters", () => {
         dataModels,
       });
     }).toThrowErrorMatchingInlineSnapshot(
-      `"The following MDX does not represent a filter: [Pokemon].[Water].[ALL].[AllMember].[Squirtle]"`,
+      `"No cube contains the hierarchies expressed in the following filter MDX: [Pokemon].[Water].[ALL].[AllMember].[Squirtle]"`,
     );
   });
 });

--- a/src/5.0_to_5.1/migrateFilters.ts
+++ b/src/5.0_to_5.1/migrateFilters.ts
@@ -8,8 +8,8 @@ import { getAllCubes } from "./getAllCubes";
 import { createFilterWithFirstMatchingCube } from "./createFilterWithFirstMatchingCube";
 
 /**
- * In 5.0, a filter in a widget/dashboard state is just an MdxExpression.
- * In 5.1, it is a Filter.
+ * In 5.0, a filter in a widget/dashboard state is just an {@link MdxExpression}.
+ * In 5.1, it is a {@link Filter}.
  * Mutates `filters`.
  */
 export function migrateFilters(

--- a/src/5.0_to_5.1/migrateFilters.ts
+++ b/src/5.0_to_5.1/migrateFilters.ts
@@ -5,7 +5,7 @@ import {
 } from "@activeviam/activeui-sdk-5.1";
 import { Mdx } from "@activeviam/activeui-sdk-5.0";
 import { getAllCubes } from "./getAllCubes";
-import { createFilterWithFirstMatchingCube } from "./createFilterWithFirstMatchingDataModel";
+import { createFilterWithFirstMatchingCube } from "./createFilterWithFirstMatchingCube";
 
 /**
  * In 5.0, a filter in a widget/dashboard state is just an MdxExpression.

--- a/src/5.0_to_5.1/migrateFilters.ts
+++ b/src/5.0_to_5.1/migrateFilters.ts
@@ -1,13 +1,38 @@
-import type { Mdx } from "@activeviam/activeui-sdk-5.0";
+import {
+  getTargetCube,
+  createFilter,
+  DataModel,
+} from "@activeviam/activeui-sdk-5.1";
+import { Mdx } from "@activeviam/activeui-sdk-5.0";
+import { getAllCubes } from "./getAllCubes";
+import { createFilterWithFirstMatchingCube } from "./createFilterWithFirstMatchingDataModel";
 
 /**
- * Wraps each filter in `filters` under an `mdx` property in an object.
- * Indeed, in 5.1 filters can have an extra `isPinned` property.
+ * In 5.0, a filter in a widget/dashboard state is just an MdxExpression.
+ * In 5.1, it is a Filter.
  * Mutates `filters`.
  */
-export function migrateFilters(filters?: Mdx[]): void {
+export function migrateFilters(
+  filters: Mdx[] | undefined,
+  {
+    dataModels,
+    cubeName,
+    serverKey,
+  }: {
+    dataModels: { [serverKey: string]: DataModel };
+    cubeName?: string;
+    serverKey?: string;
+  },
+): void {
+  const cubes = getAllCubes(dataModels);
   filters?.forEach((mdx, index) => {
-    // @ts-expect-error The point of the migration is to mutate the filters from `mdx` to `{mdx}`.
-    filters[index] = { mdx };
+    if (cubeName) {
+      const { cube } = getTargetCube({ dataModels, cubeName, serverKey });
+      // @ts-expect-error The point of the migration is to mutate the filters from MdxExpression to Filter.
+      filters[index] = createFilter(mdx, cube);
+    } else {
+      // @ts-expect-error The point of the migration is to mutate the filters from MdxExpression to Filter.
+      filters[index] = createFilterWithFirstMatchingCube(mdx, cubes);
+    }
   });
 }

--- a/src/5.0_to_5.1/migrateSavedFilter.test.ts
+++ b/src/5.0_to_5.1/migrateSavedFilter.test.ts
@@ -1,0 +1,32 @@
+import { sandboxDataModel } from "@activeviam/data-model-5.1/dist/__test_resources__";
+import { migrateSavedFilter } from "./migrateSavedFilter";
+import { parse } from "@activeviam/activeui-sdk-5.0";
+
+const dataModels = { sandbox: sandboxDataModel };
+
+const euro = "[Currency].[Currency].[ALL].[AllMember].[EUR]";
+
+describe("migrateSavedFilter", () => {
+  it("migrates a 5.0 saved filter into one usable by ActiveUI 5.1", () => {
+    expect(
+      migrateSavedFilter(
+        { mdx: parse(euro) },
+        {
+          dataModels,
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "dimensionName": "Currency",
+        "hierarchyName": "Currency",
+        "members": [
+          [
+            "AllMember",
+            "EUR",
+          ],
+        ],
+        "type": "members",
+      }
+    `);
+  });
+});

--- a/src/5.0_to_5.1/migrateSavedFilter.ts
+++ b/src/5.0_to_5.1/migrateSavedFilter.ts
@@ -1,10 +1,16 @@
-import { Filter, Mdx } from "@activeviam/activeui-sdk-5.1";
+import { Filter } from "@activeviam/activeui-sdk-5.1";
+import { MdxExpression } from "@activeviam/activeui-sdk-5.0";
 import { MigrateFilterCallback } from "../migration.types";
+import { createFilterWithFirstMatchingCube } from "./createFilterWithFirstMatchingDataModel";
+import { getAllCubes } from "./getAllCubes";
 
 /**
- * Mutates a 5.0 saved filter into one usable in 5.1.
+ * Mutates a 5.0 `filterState` into one usable in 5.1.
  */
-export const migrateSavedFilter: MigrateFilterCallback<{ mdx: Mdx }, Filter> =
-  () => {
-    // TODO implement.
-  };
+export const migrateSavedFilter: MigrateFilterCallback<
+  { mdx: MdxExpression },
+  Filter
+> = ({ mdx }, { dataModels }) => {
+  const cubes = getAllCubes(dataModels);
+  return createFilterWithFirstMatchingCube(mdx, cubes);
+};

--- a/src/5.0_to_5.1/migrateSavedFilter.ts
+++ b/src/5.0_to_5.1/migrateSavedFilter.ts
@@ -5,7 +5,7 @@ import { createFilterWithFirstMatchingCube } from "./createFilterWithFirstMatchi
 import { getAllCubes } from "./getAllCubes";
 
 /**
- * Mutates a 5.0 `filterState` into one usable in 5.1.
+ * Mutates a 5.0 saved filter into one usable in 5.1.
  */
 export const migrateSavedFilter: MigrateFilterCallback<
   { mdx: MdxExpression },

--- a/src/5.0_to_5.1/migrateSavedFilter.ts
+++ b/src/5.0_to_5.1/migrateSavedFilter.ts
@@ -1,7 +1,7 @@
 import { Filter } from "@activeviam/activeui-sdk-5.1";
 import { MdxExpression } from "@activeviam/activeui-sdk-5.0";
 import { MigrateFilterCallback } from "../migration.types";
-import { createFilterWithFirstMatchingCube } from "./createFilterWithFirstMatchingDataModel";
+import { createFilterWithFirstMatchingCube } from "./createFilterWithFirstMatchingCube";
 import { getAllCubes } from "./getAllCubes";
 
 /**

--- a/src/5.0_to_5.1/migrateWidget.ts
+++ b/src/5.0_to_5.1/migrateWidget.ts
@@ -1,4 +1,8 @@
-import { AWidgetState as AWidgetState50 } from "@activeviam/activeui-sdk-5.0";
+import {
+  AWidgetState as AWidgetState50,
+  getCubeName,
+  isWidgetWithQueryState,
+} from "@activeviam/activeui-sdk-5.0";
 import { AWidgetState as AWidgetState51 } from "@activeviam/activeui-sdk-5.1";
 import { MigrateWidgetCallback } from "../migration.types";
 import { migrateCalculatedMeasuresInWidget } from "./calculated-measures/migrateCalculatedMeasuresInWidget";
@@ -25,6 +29,16 @@ export const migrateWidget: MigrateWidgetCallback<
     namesOfCalculatedMeasuresToMigrate,
     measureToCubeMapping,
   });
-  migrateFilters(widgetState.filters);
+
+  if (isWidgetWithQueryState(widgetState)) {
+    const mdx = widgetState.query?.mdx;
+    const cubeName = mdx ? getCubeName(mdx) : undefined;
+    migrateFilters(widgetState.filters, {
+      dataModels,
+      cubeName,
+      serverKey: widgetState.serverKey,
+    });
+  }
+
   migrateContextValues(widgetState.queryContext);
 };

--- a/src/5.0_to_5.1/migrateWidget.ts
+++ b/src/5.0_to_5.1/migrateWidget.ts
@@ -30,15 +30,18 @@ export const migrateWidget: MigrateWidgetCallback<
     measureToCubeMapping,
   });
 
-  if (isWidgetWithQueryState(widgetState)) {
-    const mdx = widgetState.query.mdx;
-    const cubeName = mdx ? getCubeName(mdx) : undefined;
-    migrateFilters(widgetState.filters, {
-      dataModels,
-      cubeName,
-      serverKey: widgetState.serverKey,
-    });
-  }
+  const cubeName =
+    isWidgetWithQueryState(widgetState) && widgetState.query.mdx
+      ? getCubeName(widgetState.query.mdx)
+      : undefined;
+  const serverKey = isWidgetWithQueryState(widgetState)
+    ? widgetState.serverKey
+    : undefined;
+  migrateFilters(widgetState.filters, {
+    dataModels,
+    cubeName,
+    serverKey,
+  });
 
   migrateContextValues(widgetState.queryContext);
 };

--- a/src/5.0_to_5.1/migrateWidget.ts
+++ b/src/5.0_to_5.1/migrateWidget.ts
@@ -31,7 +31,7 @@ export const migrateWidget: MigrateWidgetCallback<
   });
 
   if (isWidgetWithQueryState(widgetState)) {
-    const mdx = widgetState.query?.mdx;
+    const mdx = widgetState.query.mdx;
     const cubeName = mdx ? getCubeName(mdx) : undefined;
     migrateFilters(widgetState.filters, {
       dataModels,

--- a/src/5.0_to_5.1/migrate_5.0_to_5.1.ts
+++ b/src/5.0_to_5.1/migrate_5.0_to_5.1.ts
@@ -4,9 +4,9 @@ import {
   deserializeWidgetState,
 } from "@activeviam/activeui-sdk-5.0";
 import {
-  stringify,
   serializeWidgetState,
   serializeDashboardState,
+  serializeFilter,
 } from "@activeviam/activeui-sdk-5.1";
 import { MigrationFunction } from "../migration.types";
 import { migrateDashboard } from "./migrateDashboard";
@@ -72,7 +72,7 @@ export const migrate_50_to_51: MigrationFunction = (
     ({ mdx }) => ({
       mdx: parse(mdx),
     }),
-    migrateSavedFilter,
-    ({ mdx }) => ({ mdx: stringify(mdx) }),
+    ({ mdx }) => migrateSavedFilter({ mdx }, { dataModels }),
+    serializeFilter,
   );
 };


### PR DESCRIPTION
Migrates filters from `MdxExpression` in 5.0 to `Filter` in 5.1.
Saved filters had an extra wrapper: `{mdx: MdxExpression}`, but in 5.1 saved filters and filters within widgets/dashboards are exactly the same.