### PR TITLE
UI-8182 - Increment widgets.removed counter when widget key in keysOfWidgetPluginsToRemove

### DIFF
--- a/src/getMigrateDashboards.ts
+++ b/src/getMigrateDashboards.ts
@@ -9,6 +9,7 @@ import {
   MigrateDashboardCallback,
   OutcomeCounters,
 } from "./migration.types";
+import { WidgetFlaggedForRemovalError } from "./WidgetFlaggedForRemovalError";
 import { _addCorruptFileErrorToReport } from "./_addCorruptFileErrorToReport";
 import { _addErrorToReport } from "./_addErrorToReport";
 import { _addWidgetErrorToReport } from "./_addWidgetErrorToReport";
@@ -111,6 +112,9 @@ export const getMigrateDashboards =
           widgetName: string;
         },
       ) => {
+        if (error instanceof WidgetFlaggedForRemovalError) {
+          counters.widgets.removed++;
+        }
         _addWidgetErrorToReport(dashboardErrorReport, error, {
           doesReportIncludeStacks,
           leafKey,


### PR DESCRIPTION
## Description

The `widgets.removed` counter is not incremented when the key of a widget within a dashboard is specified in the `--remove-widgets`. This PR fixes that.